### PR TITLE
fix(detectOverflow): wrap warning in __DEV__, tweak wording

### DIFF
--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -34,8 +34,8 @@ export function detectOverflow(
     if (__DEV__) {
       console.error(
         [
-          'PopperJS: The "detectOverflow" modifier\'s `boundaryElement` must',
-          'be a parent of the popper element',
+          'Popper: The "detectOverflow" modifier\'s `boundaryElement` must be',
+          'a parent of the popper element.',
         ].join(' ')
       );
     }

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -31,9 +31,15 @@ export function detectOverflow(
   const documentElement = options.boundaryElement.ownerDocument.documentElement;
 
   if (!options.boundaryElement.contains(popperElement)) {
-    console.error(
-      'PopperJS: "detectOverflow" can accept as `boundaryElement` only a parent node of the provided popper.'
-    );
+    if (__DEV__) {
+      console.error(
+        [
+          'PopperJS: The "detectOverflow" modifier\'s `boundaryElement` must',
+          'be a parent of the popper element',
+        ].join(' ')
+      );
+    }
+
     return state;
   }
 


### PR DESCRIPTION
I'm not sure how to handle multiple lines. We could use template literal strings, concatenation, or this joining technique. What is best?