### PR TITLE
Modified nodeName handling for web pages served as XML

### DIFF
--- a/packages/popper/src/modifiers/computeStyle.js
+++ b/packages/popper/src/modifiers/computeStyle.js
@@ -67,7 +67,7 @@ export default function computeStyle(data, options) {
   if (sideA === 'bottom') {
     // when offsetParent is <html> the positioning is relative to the bottom of the screen (excluding the scrollbar)
     // and not the bottom of the html element
-    if (offsetParent.nodeName === 'HTML') {
+    if (offsetParent.nodeName === 'HTML' || offsetParent.nodeName === 'html') {
       top = -offsetParent.clientHeight + offsets.bottom;
     } else {
       top = -offsetParentRect.height + offsets.bottom;
@@ -76,7 +76,7 @@ export default function computeStyle(data, options) {
     top = offsets.top;
   }
   if (sideB === 'right') {
-    if (offsetParent.nodeName === 'HTML') {
+    if (offsetParent.nodeName === 'HTML' || offsetParent.nodeName === 'html') {
       left = -offsetParent.clientWidth + offsets.right;
     } else {
       left = -offsetParentRect.width + offsets.right;

--- a/packages/popper/src/utils/getBoundaries.js
+++ b/packages/popper/src/utils/getBoundaries.js
@@ -41,7 +41,7 @@ export default function getBoundaries(
     let boundariesNode;
     if (boundariesElement === 'scrollParent') {
       boundariesNode = getScrollParent(getParentNode(reference));
-      if (boundariesNode.nodeName === 'BODY') {
+      if (boundariesNode.nodeName === 'BODY' || boundariesNode.nodeName === 'body') {
         boundariesNode = popper.ownerDocument.documentElement;
       }
     } else if (boundariesElement === 'window') {
@@ -57,7 +57,7 @@ export default function getBoundaries(
     );
 
     // In case of HTML, we need a different computation
-    if (boundariesNode.nodeName === 'HTML' && !isFixed(offsetParent)) {
+    if ((boundariesNode.nodeName === 'HTML' || boundariesNode.nodeName === 'html') && !isFixed(offsetParent)) {
       const { height, width } = getWindowSizes(popper.ownerDocument);
       boundaries.top += offsets.top - offsets.marginTop;
       boundaries.bottom = height + offsets.top;

--- a/packages/popper/src/utils/getBoundingClientRect.js
+++ b/packages/popper/src/utils/getBoundingClientRect.js
@@ -42,7 +42,7 @@ export default function getBoundingClientRect(element) {
   };
 
   // subtract scrollbar size from sizes
-  const sizes = element.nodeName === 'HTML' ? getWindowSizes(element.ownerDocument) : {};
+  const sizes = element.nodeName === 'HTML' || element.nodeName === 'html' ? getWindowSizes(element.ownerDocument) : {};
   const width =
     sizes.width || element.clientWidth || result.width;
   const height =

--- a/packages/popper/src/utils/getOffsetParent.js
+++ b/packages/popper/src/utils/getOffsetParent.js
@@ -23,14 +23,14 @@ export default function getOffsetParent(element) {
 
   const nodeName = offsetParent && offsetParent.nodeName;
 
-  if (!nodeName || nodeName === 'BODY' || nodeName === 'HTML') {
+  if (!nodeName || nodeName === 'BODY' || nodeName === 'body' || nodeName === 'HTML' || nodeName === 'html') {
     return element ? element.ownerDocument.documentElement : document.documentElement;
   }
 
   // .offsetParent will return the closest TH, TD or TABLE in case
   // no offsetParent is present, I hate this job...
   if (
-    ['TH', 'TD', 'TABLE'].indexOf(offsetParent.nodeName) !== -1 &&
+    ['TH', 'th', 'TD', 'td', 'TABLE', 'table'].indexOf(offsetParent.nodeName) !== -1 &&
     getStyleComputedProperty(offsetParent, 'position') === 'static'
   ) {
     return getOffsetParent(offsetParent);

--- a/packages/popper/src/utils/getOffsetRect.js
+++ b/packages/popper/src/utils/getOffsetRect.js
@@ -10,7 +10,7 @@ import getClientRect from './getClientRect';
  */
 export default function getOffsetRect(element) {
   let elementRect;
-  if (element.nodeName === 'HTML') {
+  if (element.nodeName === 'HTML' || element.nodeName === 'html') {
     const { width, height } = getWindowSizes(element.ownerDocument);
     elementRect = {
       width,

--- a/packages/popper/src/utils/getOffsetRectRelativeToArbitraryNode.js
+++ b/packages/popper/src/utils/getOffsetRectRelativeToArbitraryNode.js
@@ -7,7 +7,7 @@ import getClientRect from './getClientRect';
 
 export default function getOffsetRectRelativeToArbitraryNode(children, parent, fixedPosition = false) {
   const isIE10 = runIsIE(10);
-  const isHTML = parent.nodeName === 'HTML';
+  const isHTML = parent.nodeName === 'HTML' || parent.nodeName === 'html';
   const childrenRect = getBoundingClientRect(children);
   const parentRect = getBoundingClientRect(parent);
   const scrollParent = getScrollParent(children);
@@ -51,7 +51,7 @@ export default function getOffsetRectRelativeToArbitraryNode(children, parent, f
   if (
     isIE10 && !fixedPosition
       ? parent.contains(scrollParent)
-      : parent === scrollParent && scrollParent.nodeName !== 'BODY'
+      : parent === scrollParent && scrollParent.nodeName !== 'BODY' && scrollParent.nodeName !== 'body'
   ) {
     offsets = includeScroll(offsets, parent);
   }

--- a/packages/popper/src/utils/getParentNode.js
+++ b/packages/popper/src/utils/getParentNode.js
@@ -6,7 +6,7 @@
  * @returns {Element} parent
  */
 export default function getParentNode(element) {
-  if (element.nodeName === 'HTML') {
+  if (element.nodeName === 'HTML' || element.nodeName === 'html') {
     return element;
   }
   return element.parentNode || element.host;

--- a/packages/popper/src/utils/getScroll.js
+++ b/packages/popper/src/utils/getScroll.js
@@ -10,7 +10,7 @@ export default function getScroll(element, side = 'top') {
   const upperSide = side === 'top' ? 'scrollTop' : 'scrollLeft';
   const nodeName = element.nodeName;
 
-  if (nodeName === 'BODY' || nodeName === 'HTML') {
+  if (nodeName === 'BODY' || nodeName === 'body' || nodeName === 'HTML' || nodeName === 'html') {
     const html = element.ownerDocument.documentElement;
     const scrollingElement = element.ownerDocument.scrollingElement || html;
     return scrollingElement[upperSide];

--- a/packages/popper/src/utils/getScrollParent.js
+++ b/packages/popper/src/utils/getScrollParent.js
@@ -16,7 +16,9 @@ export default function getScrollParent(element) {
 
   switch (element.nodeName) {
     case 'HTML':
+    case 'html':
     case 'BODY':
+    case 'body':
       return element.ownerDocument.body
     case '#document':
       return element.body

--- a/packages/popper/src/utils/isFixed.js
+++ b/packages/popper/src/utils/isFixed.js
@@ -11,7 +11,7 @@ import getParentNode from './getParentNode';
  */
 export default function isFixed(element) {
   const nodeName = element.nodeName;
-  if (nodeName === 'BODY' || nodeName === 'HTML') {
+  if (nodeName === 'BODY' || nodeName === 'body' || nodeName === 'HTML' || nodeName === 'html') {
     return false;
   }
   if (getStyleComputedProperty(element, 'position') === 'fixed') {

--- a/packages/popper/src/utils/isOffsetContainer.js
+++ b/packages/popper/src/utils/isOffsetContainer.js
@@ -2,10 +2,10 @@ import getOffsetParent from './getOffsetParent';
 
 export default function isOffsetContainer(element) {
   const { nodeName } = element;
-  if (nodeName === 'BODY') {
+  if (nodeName === 'BODY' || nodeName === 'body') {
     return false;
   }
   return (
-    nodeName === 'HTML' || getOffsetParent(element.firstElementChild) === element
+    nodeName === 'HTML' || nodeName === 'html' || getOffsetParent(element.firstElementChild) === element
   );
 }

--- a/packages/popper/src/utils/setupEventListeners.js
+++ b/packages/popper/src/utils/setupEventListeners.js
@@ -2,7 +2,7 @@ import getScrollParent from './getScrollParent';
 import getWindow from './getWindow';
 
 function attachToScrollParents(scrollParent, event, callback, scrollParents) {
-  const isBody = scrollParent.nodeName === 'BODY';
+  const isBody = scrollParent.nodeName === 'BODY' || scrollParent.nodeName === 'body';
   const target = isBody ? scrollParent.ownerDocument.defaultView : scrollParent;
   target.addEventListener(event, callback, { passive: true });
 


### PR DESCRIPTION
When a web page is served with `Content-Type: application/xhtml+xml`, the DOM property `nodeName` will always have a lowercased value instead of a uppercased one typically seen in normal HTML pages.
This modification is meant to help users who want to serve their web pages with `Content-Type: application/xhtml+xml` and is not supposed to break anything.

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
