### PR TITLE
fix: blurry text

### DIFF
--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -29,8 +29,10 @@ export const computePopperStyles = ({
   strategy: PositioningStrategy,
   gpuAcceleration: boolean,
 }) => {
+  // @1x displays in Chrome can be blurry due to non-rounded offsets, but this
+  // introduces slight positioning errors. TODO: somehow solve this better
   // by default it is active, disable it only if explicitly set to false
-  if (gpuAcceleration === false) {
+  if (gpuAcceleration === false || window.devicePixelRatio < 2) {
     return {
       top: `${offsets.y}px`,
       left: `${offsets.x}px`,


### PR DESCRIPTION
Let's discuss techniques here before merging

We could:

1. Force `top/left` for  <`@2x` DPI displays (current PR)
2. Round offsets but keep `gpuAcceleration`, however sometimes this still causes blurry text (seen in several issues) due to the accelerated layer or whatever, and can cause 0.5px rounding errors for centered poppers