### PR TITLE
fix: flip should use viewport rect

### DIFF
--- a/src/dom-utils/getDocumentRect.js
+++ b/src/dom-utils/getDocumentRect.js
@@ -2,13 +2,19 @@
 import getRectRelativeToOffsetParent from './getRectRelativeToOffsetParent';
 import getWindow from './getWindow';
 import getDocumentElement from './getDocumentElement';
+import getWindowScroll from './getWindowScroll';
 
 export default (element: HTMLElement) => {
   const win = getWindow(element);
+  const winScroll = getWindowScroll(element);
   const documentRect = getRectRelativeToOffsetParent(
     getDocumentElement(element)
   );
+
   documentRect.height = Math.max(documentRect.height, win.innerHeight);
   documentRect.width = Math.max(documentRect.width, win.innerWidth);
+  document.x = -winScroll.scrollLeft;
+  document.y = -winScroll.scrollTop;
+
   return documentRect;
 };

--- a/src/dom-utils/getDocumentRect.js
+++ b/src/dom-utils/getDocumentRect.js
@@ -13,8 +13,8 @@ export default (element: HTMLElement) => {
 
   documentRect.height = Math.max(documentRect.height, win.innerHeight);
   documentRect.width = Math.max(documentRect.width, win.innerWidth);
-  document.x = -winScroll.scrollLeft;
-  document.y = -winScroll.scrollTop;
+  documentRect.x = -winScroll.scrollLeft;
+  documentRect.y = -winScroll.scrollTop;
 
   return documentRect;
 };

--- a/src/dom-utils/getViewportRect.js
+++ b/src/dom-utils/getViewportRect.js
@@ -1,0 +1,12 @@
+// @flow
+import getWindow from './getWindow';
+
+export default (element: HTMLElement) => {
+  const win = getWindow(element);
+  return {
+    width: win.innerWidth,
+    height: win.innerHeight,
+    x: 0,
+    y: 0,
+  };
+};

--- a/src/enums.js
+++ b/src/enums.js
@@ -20,6 +20,13 @@ export const edges: 'edges' = 'edges';
 export const surfaces: 'surfaces' = 'surfaces';
 export type Tether = false | typeof center | typeof edges | typeof surfaces;
 
+export const clippingParent: 'clippingParent' = 'clippingParent';
+export const viewport: 'viewport' = 'viewport';
+export type OverflowArea =
+  | HTMLElement
+  | typeof clippingParent
+  | typeof viewport;
+
 export type Placement =
   | 'auto'
   | 'auto-start'

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -4,6 +4,7 @@ import getBoundingClientRect from '../dom-utils/getBoundingClientRect';
 import getClippingParent from '../dom-utils/getClippingParent';
 import getDocumentRect from '../dom-utils/getDocumentRect';
 import getDocumentElement from '../dom-utils/getDocumentElement';
+import getViewportRect from '../dom-utils/getViewportRect';
 import computeOffsets from '../utils/computeOffsets';
 import rectToClientRect from '../utils/rectToClientRect';
 
@@ -19,6 +20,16 @@ type ModifierData = {
   right: number,
   left: number,
 };
+
+const getOverflowOffsets = (
+  popperClientRect,
+  boundaryClientRect
+): ModifierData => ({
+  top: boundaryClientRect.top - popperClientRect.top,
+  bottom: popperClientRect.bottom - boundaryClientRect.bottom,
+  left: boundaryClientRect.left - popperClientRect.left,
+  right: popperClientRect.right - boundaryClientRect.right,
+});
 
 export function detectOverflow({
   state,
@@ -44,6 +55,9 @@ export function detectOverflow({
     documentElement === options.boundaryElement
       ? rectToClientRect(getDocumentRect(documentElement))
       : getBoundingClientRect(options.boundaryElement);
+  const viewportClientRect = rectToClientRect(
+    getViewportRect(options.boundaryElement)
+  );
 
   const referenceClientRect = getBoundingClientRect(referenceElement);
 
@@ -63,12 +77,10 @@ export function detectOverflow({
     ...popperOffsets,
   });
 
-  state.modifiersData.detectOverflow = ({
-    top: boundaryClientRect.top - popperClientRect.top,
-    bottom: popperClientRect.bottom - boundaryClientRect.bottom,
-    left: boundaryClientRect.left - popperClientRect.left,
-    right: popperClientRect.right - boundaryClientRect.right,
-  }: ModifierData);
+  state.modifiersData.detectOverflow = {
+    viewport: getOverflowOffsets(popperClientRect, viewportClientRect),
+    boundary: getOverflowOffsets(popperClientRect, boundaryClientRect),
+  };
 
   return state;
 }

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -32,8 +32,6 @@ const getOverflowOffsets = (
   right: popperClientRect.right - boundaryClientRect.right,
 });
 
-const isViewport = value => value === 'viewport';
-
 export function detectOverflow({
   state,
   options = {},

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -62,8 +62,8 @@ export function detectOverflow({
   const referenceElement = state.elements.reference;
   const popperRect = state.measures.popper;
 
-  const clippingClientRect = getClientRect(state.elements.popper, clippingArea);
-  const visibleClientRect = getClientRect(state.elements.popper, visibleArea);
+  const clippingClientRect = getOverflowRect(popperElement, clippingArea);
+  const visibleClientRect = getOverflowRect(popperElement, visibleArea);
 
   const referenceClientRect = getBoundingClientRect(referenceElement);
 

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -32,6 +32,8 @@ const getOverflowOffsets = (
   right: popperClientRect.right - boundaryClientRect.right,
 });
 
+const isViewport = value => value === 'viewport';
+
 export function detectOverflow({
   state,
   options = {},
@@ -44,10 +46,10 @@ export function detectOverflow({
   const popperElement = state.elements.popper;
   const referenceElement = state.elements.reference;
   const popperRect = state.measures.popper;
-  const documentElement = getDocumentElement(clippingArea);
+  const documentElement = getDocumentElement(state.elements.popper);
 
   if (
-    typeof clippingArea !== 'stirng' &&
+    typeof clippingArea !== 'string' &&
     !clippingArea.contains(popperElement)
   ) {
     if (__DEV__) {
@@ -58,17 +60,16 @@ export function detectOverflow({
     return state;
   }
 
-  const boundaryClientRect =
+  const clippingClientRect =
     documentElement === clippingArea
       ? rectToClientRect(getDocumentRect(documentElement))
       : clippingArea === 'viewport'
       ? rectToClientRect(getViewportRect(state.elements.popper))
       : getBoundingClientRect(clippingArea);
-  const viewportClientRect = rectToClientRect(
+  const visibleClientRect =
     visibleArea === 'viewport'
       ? rectToClientRect(getViewportRect(state.elements.popper))
-      : getBoundingClientRect(visibleArea)
-  );
+      : getBoundingClientRect(visibleArea);
 
   const referenceClientRect = getBoundingClientRect(referenceElement);
 
@@ -89,8 +90,8 @@ export function detectOverflow({
   });
 
   state.modifiersData.detectOverflow = {
-    clippingArea: getOverflowOffsets(popperClientRect, boundaryClientRect),
-    visibleArea: getOverflowOffsets(popperClientRect, viewportClientRect),
+    clippingArea: getOverflowOffsets(popperClientRect, clippingClientRect),
+    visibleArea: getOverflowOffsets(popperClientRect, visibleClientRect),
   };
 
   return state;

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -10,6 +10,7 @@ import { basePlacements } from '../enums';
 type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
+  detectOverflowArea: 'clippingArea' | 'visibleArea',
 };
 
 export function flip({ state, options = {} }: ModifierArguments<Options>) {
@@ -20,8 +21,9 @@ export function flip({ state, options = {} }: ModifierArguments<Options>) {
   const {
     fallbackPlacements = defaultFallbackPlacements,
     padding = 0,
+    detectOverflowArea = 'visibleArea',
   } = options;
-  const overflow = state.modifiersData.detectOverflow.visibleArea;
+  const overflow = state.modifiersData.detectOverflow[detectOverflowArea];
   const flipIndex = state.modifiersData.flip.index;
 
   const paddingObject = mergePaddingObject(

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -10,7 +10,6 @@ import { basePlacements } from '../enums';
 type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
-  detectOverflowArea: 'clippingArea' | 'visibleArea',
 };
 
 export function flip({ state, options = {} }: ModifierArguments<Options>) {
@@ -21,9 +20,8 @@ export function flip({ state, options = {} }: ModifierArguments<Options>) {
   const {
     fallbackPlacements = defaultFallbackPlacements,
     padding = 0,
-    detectOverflowArea = 'visibleArea',
   } = options;
-  const overflow = state.modifiersData.detectOverflow[detectOverflowArea];
+  const overflow = state.modifiersData.detectOverflow.visibleArea;
   const flipIndex = state.modifiersData.flip.index;
 
   const paddingObject = mergePaddingObject(

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -21,7 +21,7 @@ export function flip({ state, options = {} }: ModifierArguments<Options>) {
     fallbackPlacements = defaultFallbackPlacements,
     padding = 0,
   } = options;
-  const overflow = state.modifiersData.detectOverflow.viewport;
+  const overflow = state.modifiersData.detectOverflow.visibleArea;
   const flipIndex = state.modifiersData.flip.index;
 
   const paddingObject = mergePaddingObject(

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -21,7 +21,7 @@ export function flip({ state, options = {} }: ModifierArguments<Options>) {
     fallbackPlacements = defaultFallbackPlacements,
     padding = 0,
   } = options;
-  const overflow = state.modifiersData.detectOverflow;
+  const overflow = state.modifiersData.detectOverflow.viewport;
   const flipIndex = state.modifiersData.flip.index;
 
   const paddingObject = mergePaddingObject(

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -45,7 +45,7 @@ export function preventOverflow({
     tether = center,
     padding = 0,
   } = options;
-  const overflow = state.modifiersData.detectOverflow;
+  const overflow = state.modifiersData.detectOverflow.boundary;
   const basePlacement = getBasePlacement(state.placement);
   const mainAxis = getMainAxisFromPlacement(basePlacement);
   const altAxis = getAltAxis(mainAxis);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -33,6 +33,8 @@ type Options = {
   tether: Tether,
   /* Sets a padding to the provided boundary */
   padding: Padding,
+  /* Determines which detectOverflow offsets to use */
+  detectOverflowArea: 'clippingArea' | 'visibleArea',
 };
 
 export function preventOverflow({
@@ -44,8 +46,9 @@ export function preventOverflow({
     altAxis: checkAltAxis = false,
     tether = center,
     padding = 0,
+    detectOverflowArea = 'clippingArea',
   } = options;
-  const overflow = state.modifiersData.detectOverflow.clippingArea;
+  const overflow = state.modifiersData.detectOverflow[detectOverflowArea];
   const basePlacement = getBasePlacement(state.placement);
   const mainAxis = getMainAxisFromPlacement(basePlacement);
   const altAxis = getAltAxis(mainAxis);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -46,9 +46,8 @@ export function preventOverflow({
     altAxis: checkAltAxis = false,
     tether = center,
     padding = 0,
-    detectOverflowArea = 'clippingArea',
   } = options;
-  const overflow = state.modifiersData.detectOverflow[detectOverflowArea];
+  const overflow = state.modifiersData.detectOverflow.clippingArea;
   const basePlacement = getBasePlacement(state.placement);
   const mainAxis = getMainAxisFromPlacement(basePlacement);
   const altAxis = getAltAxis(mainAxis);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -45,7 +45,7 @@ export function preventOverflow({
     tether = center,
     padding = 0,
   } = options;
-  const overflow = state.modifiersData.detectOverflow.boundary;
+  const overflow = state.modifiersData.detectOverflow.clippingArea;
   const basePlacement = getBasePlacement(state.placement);
   const mainAxis = getMainAxisFromPlacement(basePlacement);
   const altAxis = getAltAxis(mainAxis);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -33,8 +33,6 @@ type Options = {
   tether: Tether,
   /* Sets a padding to the provided boundary */
   padding: Padding,
-  /* Determines which detectOverflow offsets to use */
-  detectOverflowArea: 'clippingArea' | 'visibleArea',
 };
 
 export function preventOverflow({


### PR DESCRIPTION
This fixes bug 8. in #617 

I'm not sure how `flip` could use "clippingParent" or if it even should? Also in v1, you could specify your own boundary for flip but now it's forced to use viewport. Does it even make sense to use anything else - is there a case where it's not suitable?

I'm not good with the functional test thingies if you could add that would be good 🙏 