### PR TITLE
fix(debounce): simplify debounce to always return the last resolved value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -132,9 +132,9 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     // debounced, so that it only runs at most once-per-tick
     instance.update = debounce(
       () =>
-        new Promise<State>(success => {
+        new Promise<State>(resolve => {
           instance.forceUpdate();
-          success(state);
+          resolve(state);
         })
     );
 

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,15 +1,16 @@
 // @flow
 export default function microtaskDebounce(fn: Function) {
-  let called = false;
-  return () =>
-    new Promise<void>(resolve => {
-      if (called) {
-        return resolve();
-      }
-      called = true;
-      Promise.resolve().then(() => {
-        called = false;
-        resolve(fn());
+  let pending;
+  return () => {
+    if (!pending) {
+      pending = new Promise<void>(resolve => {
+        Promise.resolve().then(() => {
+          pending = undefined;
+          resolve(fn());
+        });
       });
-    });
+    }
+
+    return pending;
+  };
 }

--- a/src/utils/debounce.test.js
+++ b/src/utils/debounce.test.js
@@ -1,0 +1,30 @@
+// @flow
+import debounce from './debounce';
+
+it('should debounce all the calls in the same tick', () => {
+  let called = 0;
+  const debounced = debounce(() => {
+    called += 1;
+    return called;
+  });
+  debounced();
+  debounced();
+  return debounced().then(one => {
+    expect(called).toEqual(1);
+    expect(called).toEqual(one);
+  });
+});
+
+it('should allow next tick calls to run', () => {
+  let called = 0;
+  const debounced = debounce(() => (called += 1));
+  debounced();
+  return debounced().then(one => {
+    debounced();
+    expect(one).toEqual(1);
+    return debounced().then(two => {
+      expect(called).toEqual(2);
+      expect(called).toEqual(two);
+    });
+  });
+});


### PR DESCRIPTION
In v1 we had the `onUpdate` and `onCreate` callbacks. I previously used this to read the state so that I can update my tooltip (which is rendered in react).

Given that now we no longer have these callbacks, we should be able to do `tooltip.update().then(lastRenderedState => ...)`.

However, the debounce function was swallowing the last resolved value of the debounced function. So let's fix this, simplifying the implemementation of debounce.