### PR TITLE
feat: change modifiers signature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,10 +119,10 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           continue;
         }
 
-        const { fn, enabled, options } = state.orderedModifiers[index];
+        const { fn, enabled, options, name } = state.orderedModifiers[index];
 
         if (enabled && typeof fn === 'function') {
-          state = fn({ state, options });
+          state = fn({ state, options, name });
         }
       }
     };
@@ -186,11 +186,12 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     // defined by the modifier dependencies directive.
     // The `onLoad` function may add or alter the options of themselves
     state.orderedModifiers.forEach(
-      ({ onLoad, enabled }) =>
+      ({ onLoad, enabled, name }) =>
         enabled &&
         onLoad &&
         onLoad({
           state,
+          name,
         })
     );
 
@@ -240,7 +241,8 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
       // Run `onDestroy` modifier methods
       state.orderedModifiers.forEach(
-        ({ onDestroy, enabled }) => enabled && onDestroy && onDestroy({ state })
+        ({ onDestroy, enabled, name }) =>
+          enabled && onDestroy && onDestroy({ state, name })
       );
     };
 

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
         const { fn, enabled, options } = state.orderedModifiers[index];
 
         if (enabled && typeof fn === 'function') {
-          state = fn((state: State), options);
+          state = fn({ state, options });
         }
       }
     };
@@ -186,7 +186,12 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     // defined by the modifier dependencies directive.
     // The `onLoad` function may add or alter the options of themselves
     state.orderedModifiers.forEach(
-      ({ onLoad, enabled }) => enabled && onLoad && onLoad(state)
+      ({ onLoad, enabled }) =>
+        enabled &&
+        onLoad &&
+        onLoad({
+          state,
+        })
     );
 
     instance.enableEventListeners = (
@@ -235,7 +240,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
       // Run `onDestroy` modifier methods
       state.orderedModifiers.forEach(
-        ({ onDestroy, enabled }) => enabled && onDestroy && onDestroy(state)
+        ({ onDestroy, enabled }) => enabled && onDestroy && onDestroy({ state })
       );
     };
 

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -1,15 +1,14 @@
 // @flow
-import type { Modifier, State } from '../types';
+import type { Modifier, ModifierArguments } from '../types';
 import getNodeName from '../dom-utils/getNodeName';
 import getWindow from '../dom-utils/getWindow';
 
 // This modifier takes the styles prepared by the `computeStyles` modifier
 // and applies them to the HTMLElements such as popper and arrow
 
-export function applyStyles(state: State) {
-  const data = state.modifiersData.computeStyles;
-
+export function applyStyles({ state }: ModifierArguments<void>) {
   Object.keys(state.elements).forEach(name => {
+    const data = state.modifiersData.computeStyles;
     const style = data.styles[name] || {};
 
     const attributes = data.attributes[name] || {};
@@ -33,7 +32,7 @@ export function applyStyles(state: State) {
   return state;
 }
 
-export function onDestroy(state: State) {
+export function onDestroy({ state }: ModifierArguments<void>) {
   const data = state.modifiersData.computeStyles;
 
   Object.keys(state.elements).forEach(name => {

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { State, Modifier } from '../types';
+import type { Modifier, ModifierArguments } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import addClientRectMargins from '../dom-utils/addClientRectMargins';
 import getRectRelativeToOffsetParent from '../dom-utils/getRectRelativeToOffsetParent';
@@ -10,7 +10,7 @@ import within from '../utils/within';
 
 type Options = { element: HTMLElement | string };
 
-export function arrow(state: State, options?: Options = {}) {
+export function arrow({ state, options = {} }: ModifierArguments<Options>) {
   let { element: arrowElement = '[data-popper-arrow]' } = options;
 
   // CSS selector

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -1,5 +1,10 @@
 // @flow
-import type { State, PositioningStrategy, Offsets, Modifier } from '../types';
+import type {
+  PositioningStrategy,
+  Offsets,
+  Modifier,
+  ModifierArguments,
+} from '../types';
 
 // This modifier takes the Popper state and prepares some StyleSheet properties
 // that can be applied to the popper element to make it render in the expected position.
@@ -36,7 +41,10 @@ export const mapToStyles = ({
   }
 };
 
-export function computeStyles(state: State, options?: Options = {}) {
+export function computeStyles({
+  state,
+  options = {},
+}: ModifierArguments<Options>) {
   const { gpuAcceleration = true } = options;
 
   state.modifiersData.computeStyles = {

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -1,5 +1,5 @@
 // @flow
-import type { State, Modifier } from '../types';
+import type { ModifierArguments, Modifier } from '../types';
 import getBoundingClientRect from '../dom-utils/getBoundingClientRect';
 import getClippingParent from '../dom-utils/getClippingParent';
 import getDocumentRect from '../dom-utils/getDocumentRect';
@@ -20,12 +20,12 @@ type ModifierData = {
   left: number,
 };
 
-export function detectOverflow(
-  state: State,
-  options?: Options = {
+export function detectOverflow({
+  state,
+  options = {
     boundaryElement: getClippingParent(state.elements.popper),
-  }
-) {
+  },
+}: ModifierArguments<Options>) {
   const popperElement = state.elements.popper;
   const referenceElement = state.elements.reference;
   const popperRect = state.measures.popper;

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Placement } from '../enums';
-import type { State, Modifier, Padding } from '../types';
+import type { ModifierArguments, Modifier, Padding } from '../types';
 import getOppositePlacement from '../utils/getOppositePlacement';
 import getBasePlacement from '../utils/getBasePlacement';
 import mergePaddingObject from '../utils/mergePaddingObject';
@@ -12,7 +12,7 @@ type Options = {
   padding: Padding,
 };
 
-export function flip(state: State, options?: Options = {}) {
+export function flip({ state, options = {} }: ModifierArguments<Options>) {
   const placement = state.placement;
   const defaultFallbackPlacements = [
     getOppositePlacement(state.options.placement),

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Placement } from '../enums';
-import type { State, Modifier, Rect } from '../types';
+import type { ModifierArguments, Modifier, Rect } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 
 export function distanceAndSkiddingToXY(
@@ -34,7 +34,7 @@ type OffsetsFunction = ({
 
 type Options = { offset: ?OffsetsFunction };
 
-export function offset(state: State, options?: Options = {}) {
+export function offset({ state, options = {} }: ModifierArguments<Options>) {
   if (typeof options.offset === 'function') {
     const [x, y] = distanceAndSkiddingToXY(
       state.placement,

--- a/src/modifiers/popperOffsets.js
+++ b/src/modifiers/popperOffsets.js
@@ -1,10 +1,10 @@
 // @flow
-import type { State, Modifier } from '../types';
+import type { ModifierArguments, Modifier } from '../types';
 import computeOffsets from '../utils/computeOffsets';
 import getCommonTotalScroll from '../dom-utils/getCommonTotalScroll';
 import unwrapVirtualElement from '../dom-utils/unwrapVirtualElement';
 
-export function popperOffsets(state: State) {
+export function popperOffsets({ state }: ModifierArguments<void>) {
   // Offsets are the actual position the popper needs to have to be
   // properly positioned near its reference element
   // This is the most basic placement, and will be adjusted by

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -10,7 +10,7 @@ import {
   center,
 } from '../enums';
 import type { Tether } from '../enums';
-import type { State, Modifier, Padding } from '../types';
+import type { ModifierArguments, Modifier, Padding } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import getMainAxisFromPlacement from '../utils/getMainAxisFromPlacement';
 import getAltAxis from '../utils/getAltAxis';
@@ -35,7 +35,10 @@ type Options = {
   padding: Padding,
 };
 
-export function preventOverflow(state: State, options?: Options = {}) {
+export function preventOverflow({
+  state,
+  options = {},
+}: ModifierArguments<Options>) {
   const {
     mainAxis: checkMainAxis = true,
     altAxis: checkAltAxis = false,

--- a/src/types.js
+++ b/src/types.js
@@ -51,14 +51,18 @@ export type State = {|
   reset: boolean,
 |};
 
+export type ModifierArguments<Options> = {
+  state: State,
+  options?: Options,
+};
 export type Modifier<Options> = {|
   name: string,
   enabled: boolean,
   phase: ModifierPhases,
   requires?: Array<string>,
-  fn: (State, Options) => State,
-  onLoad?: State => void,
-  onDestroy?: State => void,
+  fn: (ModifierArguments<Options>) => State,
+  onLoad?: (ModifierArguments<Options>) => void,
+  onDestroy?: (ModifierArguments<Options>) => void,
   options?: any,
   data?: {},
 |};


### PR DESCRIPTION
Changes the modifiers signature to accept an object rather than multiple arguments.

This should make it easier to extend the API if needed.