### PR TITLE
feat: move event listeners to modifier

### DIFF
--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -1,0 +1,67 @@
+// @flow
+import type { ModifierArguments, Modifier } from '../types';
+import getWindow from '../dom-utils/getWindow';
+type Options = { scroll: boolean, resize: boolean };
+
+export function onLoad({
+  state,
+  options = {},
+  instance,
+}: ModifierArguments<Options>) {
+  const { scroll = true, resize = true } = options;
+
+  if (scroll) {
+    const scrollParents = [
+      ...state.scrollParents.reference,
+      ...state.scrollParents.popper,
+    ];
+
+    scrollParents.forEach(scrollParent =>
+      scrollParent.addEventListener('scroll', instance.update, {
+        passive: true,
+      })
+    );
+  }
+
+  if (resize) {
+    const window = getWindow(state.elements.popper);
+    window.addEventListener('resize', instance.update, {
+      passive: true,
+    });
+  }
+}
+
+export function onDestroy({
+  state,
+  options = {},
+  instance,
+}: ModifierArguments<Options>) {
+  const { scroll = true, resize = true } = options;
+
+  if (scroll) {
+    // Remove scroll event listeners
+    const scrollParents = [
+      ...state.scrollParents.reference,
+      ...state.scrollParents.popper,
+    ];
+
+    scrollParents.forEach(scrollParent =>
+      scrollParent.removeEventListener('scroll', instance.update)
+    );
+  }
+
+  if (resize) {
+    // Remove resize event listeners
+    const window = getWindow(state.elements.popper);
+    window.removeEventListener('resize', instance.update);
+  }
+}
+
+export default ({
+  name: 'offset',
+  enabled: true,
+  phase: 'write',
+  fn: ({ state }) => state,
+  onLoad,
+  onDestroy,
+}: Modifier<Options>);

--- a/src/modifiers/index.js
+++ b/src/modifiers/index.js
@@ -1,4 +1,5 @@
 // @flow
+export { default as eventListeners } from './eventListeners';
 export { default as popperOffsets } from './popperOffsets';
 export { default as detectOverflow } from './detectOverflow';
 export { default as computeStyles } from './computeStyles';

--- a/src/popper-lite.js
+++ b/src/popper-lite.js
@@ -1,9 +1,14 @@
 // @flow
 import { popperGenerator } from './index';
-import { popperOffsets, computeStyles, applyStyles } from './modifiers/index';
+import {
+  eventListeners,
+  popperOffsets,
+  computeStyles,
+  applyStyles,
+} from './modifiers/index';
 
 const createPopper = popperGenerator({
-  defaultModifiers: [popperOffsets, computeStyles, applyStyles],
+  defaultModifiers: [eventListeners, popperOffsets, computeStyles, applyStyles],
 });
 
 export { createPopper, popperGenerator };

--- a/src/types.js
+++ b/src/types.js
@@ -55,6 +55,7 @@ export type Instance = {|
   destroy: () => void,
   forceUpdate: () => void,
   update: () => Promise<void>,
+  updateOptions: (options: $Shape<Options>) => void,
 |};
 
 export type ModifierArguments<Options> = {

--- a/src/types.js
+++ b/src/types.js
@@ -51,8 +51,15 @@ export type State = {|
   reset: boolean,
 |};
 
+export type Instance = {|
+  destroy: () => void,
+  forceUpdate: () => void,
+  update: () => Promise<void>,
+|};
+
 export type ModifierArguments<Options> = {
   state: State,
+  instance: Instance,
   options?: Options,
 };
 export type Modifier<Options> = {|


### PR DESCRIPTION
With this we lose the `instance.enableEventListeners` method.

We have 3 options:

1. add it back (kinda hack-ish)
2. tell users to destroy + create when they need different options
3. create a global method to update an instance options

3 is something some people asked in the past, but considered how lightweight the popper instantiation is, I don't know if it's worth it.

(with this PR, popper-base goes below the 2kB (1.92 kB))