### PR TITLE
fix: blurry text (better)

### DIFF
--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "left": "10px",
   "position": "absolute",
   "top": "5px",
+  "transform": "",
 }
 `;
 
@@ -22,5 +23,6 @@ Object {
   "left": "10px",
   "position": "absolute",
   "top": "5px",
+  "transform": "",
 }
 `;

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -13,6 +13,15 @@ type Options = {
   gpuAcceleration?: boolean,
 };
 
+// Round the offsets to the nearest suitable subpixel based on the DPR
+const roundOffsets = ({ x, y }) => {
+  const dpr = window.devicePixelRatio;
+  return {
+    x: Math.round(x * dpr) / dpr,
+    y: Math.round(y * dpr) / dpr,
+  };
+};
+
 export const mapToStyles = ({
   offsets,
   position,
@@ -22,20 +31,24 @@ export const mapToStyles = ({
   position: PositioningStrategy,
   gpuAcceleration: boolean,
 }) => {
-  // @1x displays in Chrome can be blurry due to non-rounded offsets, but this
-  // introduces slight positioning errors. TODO: somehow solve this better
-  // by default it is active, disable it only if explicitly set to false
+  const { x, y } = roundOffsets(offsets);
+
+  // Layer acceleration can disable subpixel rendering which causes slightly
+  // blurry text on low PPI displays.
+  // Zooming can change the DPR, but it seems to report a value that will
+  // cleanly divide the values into the appropriate subpixels.
   if (gpuAcceleration === false || window.devicePixelRatio < 2) {
     return {
-      top: `${offsets.y}px`,
-      left: `${offsets.x}px`,
+      top: `${y}px`,
+      left: `${x}px`,
+      transform: '',
       position,
     };
   } else {
     return {
       top: '0px',
       left: '0px',
-      transform: `translate3d(${offsets.x}px, ${offsets.y}px, 0)`,
+      transform: `translate3d(${x}px, ${y}px, 0)`,
       position,
     };
   }


### PR DESCRIPTION
After testing, subpixel values like `.75px` causes blurry text on my retina display, so we'll need to round the values. We can do this to the nearest suitable subpixel reported by `window.devicePixelRatio`

We still need to disable `transform` on low PPI displays because layer acceleration can disable subpixel rendering which leads to slightly blurry text

Fixes #764 (forever hopefully)