### PR TITLE
feat: root overflow areas

### DIFF
--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -1,5 +1,8 @@
 // @flow
 import type { VirtualElement, ClientRectObject } from '../types';
+import type { RootOverflowArea } from '../enums';
+import { viewport } from '../enums';
+import getViewportRect from './getViewportRect';
 import getDocumentRect from './getDocumentRect';
 import listScrollParents from './listScrollParents';
 import getOffsetParent from './getOffsetParent';
@@ -36,7 +39,8 @@ function getClippingParents(elementOrVirtualElement: Element | VirtualElement) {
 // Gets the maximum area that the element is visible in due to any number of
 // clipping parents
 export default function getClippingRect(
-  elementOrVirtualElement: Element | VirtualElement
+  elementOrVirtualElement: Element | VirtualElement,
+  rootArea: RootOverflowArea
 ): ClientRectObject {
   const element = unwrapVirtualElement(elementOrVirtualElement);
   const documentElement = getDocumentElement(element);
@@ -44,8 +48,17 @@ export default function getClippingRect(
     element
   );
 
-  if (firstClippingParent === documentElement || !firstClippingParent) {
+  // Fallback to document
+  if (
+    rootArea === 'document' &&
+    (firstClippingParent === documentElement || !firstClippingParent)
+  ) {
     return rectToClientRect(getDocumentRect(documentElement));
+  }
+
+  // Fallback to viewport
+  if (rootArea === viewport && !firstClippingParent) {
+    return rectToClientRect(getViewportRect(element));
   }
 
   const clippingRect = restClippingParents.reduce((accRect, clippingParent) => {

--- a/src/enums.js
+++ b/src/enums.js
@@ -26,6 +26,7 @@ export type OverflowArea =
   | HTMLElement
   | typeof clippingParents
   | typeof viewport;
+export type RootOverflowArea = typeof viewport | 'document';
 
 export const popper: 'popper' = 'popper';
 export const reference: 'reference' = 'reference';

--- a/src/modifiers/detectOverflow.js
+++ b/src/modifiers/detectOverflow.js
@@ -5,7 +5,7 @@ import type {
   ClientRectObject,
   VirtualElement,
 } from '../types';
-import type { OverflowArea, Context } from '../enums';
+import type { RootOverflowArea, OverflowArea, Context } from '../enums';
 import getBoundingClientRect from '../dom-utils/getBoundingClientRect';
 import getClippingRect from '../dom-utils/getClippingRect';
 import getViewportRect from '../dom-utils/getViewportRect';
@@ -23,6 +23,7 @@ import unwrapVirtualElement from '../dom-utils/unwrapVirtualElement';
 
 type Options = {
   area: OverflowArea,
+  rootArea: RootOverflowArea,
   elementContext: Context,
   altArea: boolean,
 };
@@ -48,13 +49,14 @@ const getOverflowOffsets = (
 
 const getOverflowRect = (
   elementOrVirtualElement: Element | VirtualElement,
-  area: OverflowArea
+  area: OverflowArea,
+  rootArea: RootOverflowArea
 ): ClientRectObject => {
   const element = unwrapVirtualElement(elementOrVirtualElement);
 
   switch (area) {
     case 'clippingParents':
-      return getClippingRect(element);
+      return getClippingRect(element, rootArea);
     case 'viewport':
       return rectToClientRect(getViewportRect(element));
     default:
@@ -69,6 +71,7 @@ export function detectOverflow({
 }: ModifierArguments<Options>) {
   const {
     area = clippingParents,
+    rootArea = 'document',
     elementContext = popper,
     altArea = false,
   } = options;
@@ -79,7 +82,7 @@ export function detectOverflow({
   const popperRect = state.measures.popper;
   const element = state.elements[altArea ? altContext : elementContext];
 
-  const clippingClientRect = getOverflowRect(element, area);
+  const clippingClientRect = getOverflowRect(element, area, rootArea);
 
   const referenceClientRect = getBoundingClientRect(referenceElement);
 

--- a/src/popper.js
+++ b/src/popper.js
@@ -1,6 +1,6 @@
 // @flow
 import { popperGenerator } from './index';
-import { clippingParents, viewport } from './enums';
+import { viewport } from './enums';
 import eventListeners from './modifiers/eventListeners';
 import popperOffsets from './modifiers/popperOffsets';
 import detectOverflow from './modifiers/detectOverflow';
@@ -17,12 +17,11 @@ const defaultModifiers = [
   {
     ...detectOverflow,
     name: 'detectOverflow:preventOverflow',
-    options: { area: clippingParents },
   },
   {
     ...detectOverflow,
     name: 'detectOverflow:flip',
-    options: { area: viewport },
+    options: { rootArea: viewport },
   },
   computeStyles,
   applyStyles,

--- a/tests/visual/modifiers/flip/index.html
+++ b/tests/visual/modifiers/flip/index.html
@@ -6,6 +6,7 @@
     width: 300px;
     height: 300px;
     background-color: grey;
+    position: relative;
   }
 
   .scroll2 {


### PR DESCRIPTION
We need to be able to specify a "root" area that overflow will fallback to.

`flip` goes from `clippingParents` to the `viewport` root, while `preventOverflow` (usually) goes back to the `document` root while "skipping" the viewport. Sometimes users choose viewport for preventOverflow  for the root though.

```ts
type Options = {
  area: OverflowArea,
  rootArea: RootOverflowArea,
  elementContext: Context,
  altArea: boolean,
};
```

There was an idea to specify `[area, ...fallbackAreas]` but it didn't really work.