### PR TITLE
Use prepare instead of postinstall for patch-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:dev": "NODE_ENV=development babel src -d tests/visual/dist",
     "build:typescript": "rimraf dist/typescript; flow-to-ts \"src/**/*.js\" --write --inline-utility-types; node typescript/ts.js --project .config/tsconfig.json --outDir dist/typescript; rimraf \"src/**/*.ts\"",
     "prepublishOnly": "yarn build",
-    "postinstall": "patch-package"
+    "prepare": "patch-package"
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
so that patch-package doesn't run when popperjs imported as a dependency

# Motivation
Installing popper.js@next as a dependency in a project will typically fail, because "patch-package" likely won't be present in the host project

# Justification
It seems that the patches are only needed at build-time - in this case, switching to `prepare` achieves the same effect without affecting downstream dependents

<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->
