### PR TITLE
refactor: various apis

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A kickass library used to manage poppers in web applications",
   "main": "dist/cjs/popper.js",
   "main:umd": "dist/umd/popper.js",
-  "module": "lib/popper-lite.js",
+  "module": "lib/popper.js",
   "unpkg": "dist/umd/popper.min.js",
   "author": "Federico Zivolo <federico.zivolo@gmail.com>",
   "license": "MIT",

--- a/src/dom-utils/getClippingRect.js
+++ b/src/dom-utils/getClippingRect.js
@@ -1,6 +1,6 @@
 // @flow
 import type { VirtualElement, ClientRectObject } from '../types';
-import type { RootOverflowArea } from '../enums';
+import type { RootBoundary } from '../enums';
 import { viewport } from '../enums';
 import getViewportRect from './getViewportRect';
 import getDocumentRect from './getDocumentRect';
@@ -40,7 +40,7 @@ function getClippingParents(elementOrVirtualElement: Element | VirtualElement) {
 // clipping parents
 export default function getClippingRect(
   elementOrVirtualElement: Element | VirtualElement,
-  rootArea: RootOverflowArea
+  rootBoundary: RootBoundary
 ): ClientRectObject {
   const element = unwrapVirtualElement(elementOrVirtualElement);
   const documentElement = getDocumentElement(element);
@@ -50,14 +50,14 @@ export default function getClippingRect(
 
   // Fallback to document
   if (
-    rootArea === 'document' &&
+    rootBoundary === 'document' &&
     (firstClippingParent === documentElement || !firstClippingParent)
   ) {
     return rectToClientRect(getDocumentRect(documentElement));
   }
 
   // Fallback to viewport
-  if (rootArea === viewport && !firstClippingParent) {
+  if (rootBoundary === viewport && !firstClippingParent) {
     return rectToClientRect(getViewportRect(element));
   }
 

--- a/src/enums.js
+++ b/src/enums.js
@@ -17,11 +17,8 @@ export type VariationPlacement = typeof start | typeof end;
 
 export const clippingParents: 'clippingParents' = 'clippingParents';
 export const viewport: 'viewport' = 'viewport';
-export type OverflowArea =
-  | HTMLElement
-  | typeof clippingParents
-  | typeof viewport;
-export type RootOverflowArea = typeof viewport | 'document';
+export type Boundary = HTMLElement | typeof clippingParents;
+export type RootBoundary = typeof viewport | 'document';
 
 export const popper: 'popper' = 'popper';
 export const reference: 'reference' = 'reference';

--- a/src/modifiers/__snapshots__/computeStyles.test.js.snap
+++ b/src/modifiers/__snapshots__/computeStyles.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`computes the arrow styles 1`] = `
 Object {
-  "left": "10px",
+  "left": "0",
   "position": "absolute",
-  "top": "5px",
-  "transform": "",
+  "top": "0",
+  "transform": "translate(10px, 5px)",
 }
 `;
 

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -1,7 +1,11 @@
 // @flow
 import type { ModifierArguments, Modifier } from '../types';
 import getWindow from '../dom-utils/getWindow';
-type Options = { scroll: boolean, resize: boolean };
+
+type Options = {
+  scroll: boolean,
+  resize: boolean,
+};
 
 const passive = { passive: true };
 

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Placement, OverflowArea, RootOverflowArea } from '../enums';
+import type { Placement, Boundary, RootBoundary } from '../enums';
 import type { ModifierArguments, Modifier, Padding } from '../types';
 import getOppositePlacement from '../utils/getOppositePlacement';
 import getBasePlacement from '../utils/getBasePlacement';
@@ -22,8 +22,8 @@ import detectOverflow from '../utils/detectOverflow';
 type Options = {
   fallbackPlacements: Array<Placement>,
   padding: Padding,
-  area: OverflowArea,
-  rootArea: RootOverflowArea,
+  boundary: Boundary,
+  rootBoundary: RootBoundary,
   flipVariations: boolean,
 };
 
@@ -42,8 +42,8 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
   const {
     fallbackPlacements: specifiedFallbackPlacements,
     padding = 0,
-    area = clippingParents,
-    rootArea = viewport,
+    boundary = clippingParents,
+    rootBoundary = viewport,
     flipVariations = true,
   } = options;
 
@@ -71,8 +71,8 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
 
   const overflow = detectOverflow(state, {
     placement: flippedPlacement,
-    area,
-    rootArea,
+    boundary,
+    rootBoundary,
   });
 
   if (!flippedPlacement) {

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -33,7 +33,7 @@ function hide({ state, name }: ModifierArguments<Options>) {
     elementContext: 'reference',
   });
   const popperAltOverflow = detectOverflow(state, {
-    altArea: true,
+    altBoundary: true,
   });
 
   const referenceClippingOffsets = getOffsets(referenceOverflow, referenceRect);

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -58,7 +58,7 @@ function offset({ state, options, name }: ModifierArguments<Options>) {
 export default ({
   name: 'offset',
   enabled: true,
-  phase: 'read',
+  phase: 'main',
   requires: ['popperOffsets'],
   fn: offset,
 }: Modifier<Options>);

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -7,7 +7,7 @@ import {
   bottom,
   clippingParents,
 } from '../enums';
-import type { Placement, OverflowArea, RootOverflowArea } from '../enums';
+import type { Placement, Boundary, RootBoundary } from '../enums';
 import type { Rect, ModifierArguments, Modifier, Padding } from '../types';
 import getBasePlacement from '../utils/getBasePlacement';
 import getMainAxisFromPlacement from '../utils/getMainAxisFromPlacement';
@@ -33,9 +33,9 @@ type Options = {
   /* Prevents boundaries overflow on the alternate axis */
   altAxis: boolean,
   /* The area to check the popper is overflowing in */
-  area: OverflowArea,
+  boundary: Boundary,
   /* If the popper is not overflowing the main area, fallback to this one */
-  rootArea: RootOverflowArea,
+  rootBoundary: RootBoundary,
   /**
    * Allows the popper to overflow from its boundaries to keep it near its
    * reference element
@@ -51,14 +51,14 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
   const {
     mainAxis: checkMainAxis = true,
     altAxis: checkAltAxis = false,
-    area = clippingParents,
-    rootArea = 'document',
+    boundary = clippingParents,
+    rootBoundary = 'document',
     tether = true,
     tetherOffset = 0,
     padding = 0,
   } = options;
 
-  const overflow = detectOverflow(state, { area, rootArea });
+  const overflow = detectOverflow(state, { boundary, rootBoundary });
   const basePlacement = getBasePlacement(state.placement);
   const mainAxis = getMainAxisFromPlacement(basePlacement);
   const altAxis = getAltAxis(mainAxis);

--- a/src/popper.js
+++ b/src/popper.js
@@ -8,6 +8,7 @@ import offset from './modifiers/offset';
 import flip from './modifiers/flip';
 import preventOverflow from './modifiers/preventOverflow';
 import arrow from './modifiers/arrow';
+import hide from './modifiers/hide';
 
 const defaultModifiers = [
   eventListeners,
@@ -18,6 +19,7 @@ const defaultModifiers = [
   flip,
   preventOverflow,
   arrow,
+  hide,
 ];
 
 const createPopper = popperGenerator({ defaultModifiers });

--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -1,14 +1,8 @@
 // @flow
 import type { State, ClientRectObject, VirtualElement } from '../types';
-import type {
-  Placement,
-  RootOverflowArea,
-  OverflowArea,
-  Context,
-} from '../enums';
+import type { Placement, Boundary, RootBoundary, Context } from '../enums';
 import getBoundingClientRect from '../dom-utils/getBoundingClientRect';
 import getClippingRect from '../dom-utils/getClippingRect';
-import getViewportRect from '../dom-utils/getViewportRect';
 import computeOffsets from '../utils/computeOffsets';
 import rectToClientRect from '../utils/rectToClientRect';
 import {
@@ -23,10 +17,10 @@ import unwrapVirtualElement from '../dom-utils/unwrapVirtualElement';
 
 type Options = {
   placement: Placement,
-  area: OverflowArea,
-  rootArea: RootOverflowArea,
+  boundary: Boundary,
+  rootBoundary: RootBoundary,
   elementContext: Context,
-  altArea: boolean,
+  altBoundary: boolean,
 };
 
 // if the number is positive, the popper is overflowing by that number of pixels
@@ -50,19 +44,16 @@ const getOverflowOffsets = (
 
 const getOverflowRect = (
   elementOrVirtualElement: Element | VirtualElement,
-  area: OverflowArea,
-  rootArea: RootOverflowArea
+  boundary: Boundary,
+  rootBoundary: RootBoundary
 ): ClientRectObject => {
   const element = unwrapVirtualElement(elementOrVirtualElement);
 
-  switch (area) {
-    case 'clippingParents':
-      return getClippingRect(element, rootArea);
-    case 'viewport':
-      return rectToClientRect(getViewportRect(element));
-    default:
-      return getBoundingClientRect(area);
+  if (boundary === 'clippingParents') {
+    return getClippingRect(element, rootBoundary);
   }
+
+  return getBoundingClientRect(boundary);
 };
 
 export default function detectOverflow(
@@ -71,19 +62,19 @@ export default function detectOverflow(
 ): OverflowOffsets {
   const {
     placement = state.placement,
-    area = clippingParents,
-    rootArea = 'document',
+    boundary = clippingParents,
+    rootBoundary = 'document',
     elementContext = popper,
-    altArea = false,
+    altBoundary = false,
   } = options;
 
   const altContext = elementContext === popper ? reference : popper;
 
   const referenceElement = state.elements.reference;
   const popperRect = state.measures.popper;
-  const element = state.elements[altArea ? altContext : elementContext];
+  const element = state.elements[altBoundary ? altContext : elementContext];
 
-  const clippingClientRect = getOverflowRect(element, area, rootArea);
+  const clippingClientRect = getOverflowRect(element, boundary, rootBoundary);
   const referenceClientRect = getBoundingClientRect(referenceElement);
 
   const popperOffsets = computeOffsets({


### PR DESCRIPTION
Working on the docs helped me realize to refactor these:

- Rename `OverflowArea` to `Boundary` and use `boundary` over `area`
- Remove `viewport` as a `Boundary` (it's a root)
- Use 2D transforms when `gpuAcceleration` is enabled for low PPI displays. I think that only 3D transforms disable subpixel text rendering?
- Change `offset` to `main` phase since `detectOverflow` is no longer a modifier
- Export `hide` as a default modifier (only `0.2kb` gzip for the full file)
- Change `computeStyles` phase to `beforeWrite`
- Change the default `esm` to the full Popper like `cjs` and `umd`. I think it's too confusing to make Lite default – tree-shaking should be opt-in, than opt-out by default. I can see this being a frustrating default. A lot of people likely just want it to "work" on first try with the default import. Once they've used the features they need, they can convert it to a tree-shakable version if wanted.