### PR TITLE
docs: route ordering and utils docs

### DIFF
--- a/docs/src/components/Layout.js
+++ b/docs/src/components/Layout.js
@@ -14,8 +14,9 @@ import { Global, css } from '@emotion/core';
 import CarbonAds from './CarbonAds';
 import { Container, media } from './Framework';
 import { MdxRoutes } from '@pauliescanlon/gatsby-mdx-routes';
+import Navigation, { NAVIGATION_WIDTH } from './Navigation';
+import processRoutes from '../utils/processRoutes';
 
-import Navigation, { NAVIGATION_WIDTH, BLACKLIST } from './Navigation';
 import './layout.css';
 import './prism-base2tone-pool-dark.css';
 
@@ -119,20 +120,12 @@ const components = {
 
 const Layout = ({ children, path }) => {
   function getPrevNextRoutes(routes) {
-    const validRoutes = routes
-      .filter(
-        route => !BLACKLIST.includes(route) && route.slug.includes('modifiers')
-      )
-      .map(route => ({
-        ...route,
-        slug: route.slug.replace(/\/$/, ''),
-      }));
-
+    const validRoutes = processRoutes(routes);
     const slashlessPath = path.replace(/\/$/, '');
 
-    const currentPathIndex = validRoutes
-      .sort((a, b) => a.index - b.index)
-      .findIndex(route => route.slug === slashlessPath);
+    const currentPathIndex = validRoutes.findIndex(
+      route => route.slug === slashlessPath
+    );
 
     return {
       prev: validRoutes[currentPathIndex - 1],

--- a/docs/src/components/Navigation.js
+++ b/docs/src/components/Navigation.js
@@ -4,11 +4,11 @@ import styled from '@emotion/styled';
 import { css } from '@emotion/core';
 import { MdxRoutes } from '@pauliescanlon/gatsby-mdx-routes';
 import { createTree } from '../utils/createTree';
+import processRoutes from '../utils/processRoutes';
 import { media } from './Framework';
 
 import popperText from '../images/popper-text.svg';
 
-export const BLACKLIST = ['/404'];
 export const NAVIGATION_WIDTH = 250;
 
 const Container = styled.div`
@@ -155,11 +155,9 @@ const Block = ({ route }) => (
         </Item>
       </li>
       <Ul root={route.slug.split('/').length === 1}>
-        {route.children
-          .sort((a, b) => a.children.length - b.children.length)
-          .map((route, index) => (
-            <Block key={index} route={route} />
-          ))}
+        {route.children.map((route, index) => (
+          <Block key={index} route={route} />
+        ))}
       </Ul>
     </Ul>
   </>
@@ -194,19 +192,7 @@ export default function Navigation({ description, lang, meta, title }) {
             <PopperTextLogo />
             <CloseMenuButton onClick={closeMenu}>Close Menu</CloseMenuButton>
             <MenuContents>
-              {createTree(
-                routes
-                  .map(route => ({
-                    ...route,
-                    slug: route.slug.replace(/\/$/, ''),
-                  }))
-                  .filter(route => !BLACKLIST.includes(route.slug))
-                  .sort(
-                    (a, b) =>
-                      a.slug.split('/').length - b.slug.split('/').length
-                  )
-                  .sort((a, b) => a.index - b.index)
-              ).map((route, index) => (
+              {createTree(processRoutes(routes)).map((route, index) => (
                 <Block route={route} key={index} />
               ))}
             </MenuContents>

--- a/docs/src/pages/docs/utils/detectOverflow.mdx
+++ b/docs/src/pages/docs/utils/detectOverflow.mdx
@@ -1,0 +1,74 @@
+---
+title: Detect Overflow
+---
+
+# Detect Overflow
+
+The `detectOverflow` utility returns an object of overflow offsets of the popper
+or reference element relative to a given boundary.
+
+```js
+import detectOverflow from '@popperjs/core/lib/utils/detectOverflow';
+
+const overflow = detectOverflow(state, options);
+```
+
+You can use this utility within your own custom modifiers.
+
+## State
+
+The first argument is the popper instance state that gets passed in to
+modifiers.
+
+## Options
+
+```flow
+type Options = {
+  placement: Placement, // state.placement
+  boundary: Boundary, // "clippingParents"
+  rootBoundary: RootBoundary, // "document"
+  elementContext: Context, // "popper"
+  altBoundary: boolean, // false
+};
+
+// Below are the relative types
+// See `preventOverflow` or `flip` for the others
+type Context = 'reference' | 'popper';
+```
+
+### `placement`
+
+This will check the overflow when the popper is given this placement, even if
+it's not the current `state.placement`.
+
+### `boundary`
+
+The same `Boundary` type that `preventOverflow` and `flip` accept.
+
+### `rootBoundary`
+
+The same `RootBoundary` type that `preventOverflow` and `flip` accept.
+
+### `elementContext`
+
+This describes the element that is being checked for overflow relative to the
+boundary.
+
+### `altBoundary`
+
+This describes whether to use the alt element's boundary. For example, if the
+`elementContext` is `"popper"`, then it will check the reference's boundary
+context, and vice-versa.
+
+## Return value
+
+```flow
+// If the number is positive, the popper is overflowing by that number of pixels.
+// When 0, or negative, the popper is within its boundaries.
+type OverflowOffsets = {
+  top: number,
+  bottom: number,
+  right: number,
+  left: number,
+};
+```

--- a/docs/src/pages/docs/utils/index.mdx
+++ b/docs/src/pages/docs/utils/index.mdx
@@ -1,0 +1,7 @@
+---
+title: Utils
+---
+
+# Utils
+
+Utils are helper functions provided by the library.

--- a/docs/src/utils/processRoutes.js
+++ b/docs/src/utils/processRoutes.js
@@ -1,0 +1,43 @@
+const BLACKLIST = new Set(['/404/']);
+const DIR_ORDER = ['modifiers', 'utils', 'typings'];
+const MODIFIER_ORDER = [
+  'Popper Offsets',
+  'Offset',
+  'Prevent Overflow',
+  'Arrow',
+  'Flip',
+  'Hide',
+  'Compute Styles',
+  'Apply Styles',
+  'Event Listeners',
+];
+
+// I think this takes 0.5ms - 1ms on my MBP, we need to optimize this...
+export default function processRoutes(routes) {
+  const preprocessedRoutes = routes
+    .filter(route => !BLACKLIST.has(route.slug))
+    .map(route => {
+      // Cloning is expensive, make sure mutating here isn't a problem
+      // Removes the trailing slash
+      route.slug = route.slug.replace(/\/$/, '');
+      return route;
+    })
+    .sort((a, b) => a.slug.split('/').length - b.slug.split('/').length)
+    .sort(
+      (a, b) =>
+        MODIFIER_ORDER.indexOf(a.title) - MODIFIER_ORDER.indexOf(b.title)
+    );
+
+  return [
+    ...preprocessedRoutes.filter(
+      route => !DIR_ORDER.some(type => route.slug.includes(type))
+    ),
+    ...DIR_ORDER.reduce(
+      (acc, type) => [
+        ...acc,
+        ...preprocessedRoutes.filter(route => route.slug.includes(type)),
+      ],
+      []
+    ),
+  ];
+}


### PR DESCRIPTION
We want to order like:

- `Home`
- `Documentation`
    - `Modifiers`
        - `Popper Offsets`
        - `...` (based on default dependencies and phase, we can manually specify this?)
    - `Utils`
        - `Detect Overflow`
    - `Typings`

Tried using `index` in the frontmatter but the `MdxRoutes` plugin doesn't seem to pick it up.

`docs/src/utils/processRoutes.js` algorithm is so inefficient/brittle 😥, needs improvement, pls help @FezVrasta 😄 