### PR TITLE
fix: defends against undefined tooltip.popperInstance

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -362,9 +362,9 @@ export default class Tooltip {
           if (!this._isOpening) {
             return;
           }
-          const popper = this.popperInstance.popper;
           if (reference.contains(e.target) ||
-              popper.contains(e.target)) {
+              this.popperInstance &&
+              this.popperInstance.popper.contains(e.target)) {
             return;
           }
           func(e);


### PR DESCRIPTION
<!--
Thanks for your interest in contributing to Popper.js!

Please, make sure to fulfill the following conditions before submitting your Pull Request:

1. Make sure the tests are passing by running `yarn test` with Google Chrome installed.

2. Add any relevant tests to cover the code you have changed and/or added.

3. If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.


Problems signing the CLA? Try this link:
https://cla-assistant.io/FezVrasta/popper.js
-->

Fixes an issue that if `this.popperInstance` has already been destroyed when the `mousedown` callback is executed, the app crashes with `"cannot read property 'popper' of undefined"`

- [x] the tests are passing by running `yarn test`

NA -- Add any relevant tests to cover the code you have changed and/or added.

NA -- If you change the public API, try to update the Typescript definitions accordingly:
  https://github.com/FezVrasta/popper.js/blob/master/packages/popper/index.d.ts
  This is not required but will help a lot. Mention @giladgray for help as needed.