### PR TITLE
fix: getClippingRect / detectOverflow calculations

### DIFF
--- a/src/enums.js
+++ b/src/enums.js
@@ -17,7 +17,10 @@ export type Variation = typeof start | typeof end;
 
 export const clippingParents: 'clippingParents' = 'clippingParents';
 export const viewport: 'viewport' = 'viewport';
-export type Boundary = HTMLElement | typeof clippingParents;
+export type Boundary =
+  | HTMLElement
+  | Array<HTMLElement>
+  | typeof clippingParents;
 export type RootBoundary = typeof viewport | 'document';
 
 export const popper: 'popper' = 'popper';

--- a/src/modifiers/__snapshots__/offset.test.js.snap
+++ b/src/modifiers/__snapshots__/offset.test.js.snap
@@ -1,29 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`bottom 1`] = `
-Array [
-  20,
-  10,
-]
+Object {
+  "x": 20,
+  "y": 10,
+}
 `;
 
 exports[`left 1`] = `
-Array [
-  -10,
-  20,
-]
+Object {
+  "x": -10,
+  "y": 20,
+}
 `;
 
 exports[`right 1`] = `
-Array [
-  10,
-  20,
-]
+Object {
+  "x": 10,
+  "y": 20,
+}
 `;
 
 exports[`top 1`] = `
-Array [
-  20,
-  -10,
-]
+Object {
+  "x": 20,
+  "y": -10,
+}
 `;

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -1,27 +1,26 @@
 // @flow
-import type { ModifierArguments, Modifier, Rect, Options } from '../types';
+import type {
+  ModifierArguments,
+  Modifier,
+  Rect,
+  Options,
+  SideObject,
+} from '../types';
 import { top, bottom, left, right } from '../enums';
 import detectOverflow from '../utils/detectOverflow';
 
-type ModifierData = {
-  top: number,
-  bottom: number,
-  right: number,
-  left: number,
-};
-
 const getOffsets = (
-  overflow: ModifierData,
+  overflow: SideObject,
   rect: Rect,
   preventedOffsets: { x: number, y: number } = { x: 0, y: 0 }
-): ModifierData => ({
+): SideObject => ({
   top: overflow.top - rect.height - preventedOffsets.y,
   right: overflow.right - rect.width + preventedOffsets.x,
   bottom: overflow.bottom - rect.height + preventedOffsets.y,
   left: overflow.left - rect.width - preventedOffsets.x,
 });
 
-const isAnySideFullyClipped = (overflow: ModifierData): boolean =>
+const isAnySideFullyClipped = (overflow: SideObject): boolean =>
   [top, right, bottom, left].some(side => overflow[side] >= 0);
 
 function hide({ state, name }: ModifierArguments<Options>) {
@@ -62,7 +61,7 @@ function hide({ state, name }: ModifierArguments<Options>) {
   return state;
 }
 
-const hideModifier = ({
+export default ({
   name: 'hide',
   enabled: true,
   phase: 'main',
@@ -70,6 +69,3 @@ const hideModifier = ({
   optionallyRequires: ['preventOverflow'],
   fn: hide,
 }: Modifier<Options>);
-
-// eslint-disable-next-line import/no-unused-modules
-export default hideModifier;

--- a/src/types.js
+++ b/src/types.js
@@ -100,14 +100,14 @@ export type ClientRectObject = {|
   height: number,
 |};
 
-export type PaddingObject = {|
+export type SideObject = {|
   top: number,
   left: number,
   right: number,
   bottom: number,
 |};
 
-export type Padding = number | $Shape<PaddingObject>;
+export type Padding = number | $Shape<SideObject>;
 
 export type VirtualElement = {|
   contextElement: HTMLElement,

--- a/src/utils/getFreshSideObject.js
+++ b/src/utils/getFreshSideObject.js
@@ -1,0 +1,4 @@
+// @flow
+import type { SideObject } from '../types';
+
+export default (): SideObject => ({ top: 0, right: 0, bottom: 0, left: 0 });

--- a/src/utils/mergePaddingObject.js
+++ b/src/utils/mergePaddingObject.js
@@ -1,10 +1,8 @@
 // @flow
-import type { PaddingObject } from '../types';
+import type { SideObject } from '../types';
+import getFreshSideObject from './getFreshSideObject';
 
-export default (paddingObject: $Shape<PaddingObject>): PaddingObject => ({
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
+export default (paddingObject: $Shape<SideObject>): SideObject => ({
+  ...getFreshSideObject(),
   ...paddingObject,
 });


### PR DESCRIPTION
## 1. Include `rootBoundary` in the `clippingRect` reducer calculation

This is because the viewport bottom could be above the clippingParents bottom, for example. 

This allows for the `[...boundaryElements, rootBoundary]` pattern, so you can use an array of elements for `boundary` (#598):

```js
// Gets the minimum bounds of all of these boundaries
// (aka the maximum area the element is visible in)
boundary: [element1, element2, ...],
rootBoundary: 'viewport'
```

It doesn't really work like a "fallback", rather a list of elements whose rects will be reduced into a virtual area that can clip the element. @whitecolor

I think it still makes sense to split the `root`, as it can be easy to forget to need to use an array to specify a root placement when using an element.

## 2. `offset` needs to provide info about each placement

There was a problem with `detectOverflow`'s `offset` calculation. It was using the `state.placement`'s `offset`, but we need to know what the `offset` will be for `options.placement`. To solve we can reduce all of the `placements` into an object that contains offset data for each placement, e.g.

```js
state.modifiersData.offset = {
  'top': {x: number, y: number},
  'top-start', {x: number, y: number},
  'top-end': {x: number, y: number},
  'right': {x: number, y: number},
  ...
};
```

Which means it runs 12 calculations...  but based on my perf tests, it doesn't affect it at all (well within noise variations)

## 3. More generic `SideObject` type

This replaces `PaddingObject` and others as a more generic type that can be used in a wide variety of scenarios: it's an object with four sides where each value is a number, which is used throughout the library for various data

```ts
type SideObject = {|
  top: number,
  right: number,
  bottom: number,
  left: number,
|};
```