### PR TITLE
fix: popper instance

### DIFF
--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`returns expected instance object 1`] = `
+Object {
+  "destroy": [Function],
+  "forceUpdate": [Function],
+  "setOptions": [Function],
+  "state": Object {
+    "attributes": Object {},
+    "elements": Object {
+      "popper": <div />,
+      "reference": <div />,
+    },
+    "isCreated": true,
+    "modifiersData": Object {},
+    "options": Object {
+      "modifiers": Array [],
+      "placement": "bottom",
+      "strategy": "absolute",
+    },
+    "orderedModifiers": Array [],
+    "placement": "bottom",
+    "scrollParents": Object {
+      "popper": Array [
+        [Window],
+      ],
+      "reference": Array [
+        [Window],
+      ],
+    },
+    "styles": Object {},
+  },
+  "update": [Function],
+}
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ import unwrapJqueryElement from './utils/unwrapJqueryElement';
 import orderModifiers from './utils/orderModifiers';
 import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';
+import uniqueBy from './utils/uniqueBy';
 
 const INVALID_ELEMENT_ERROR =
   'Popper: Invalid reference or popper argument provided to Popper, they must be either a valid DOM element, virtual element, or a jQuery-wrapped DOM element.';
@@ -106,15 +107,11 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
         // if one of the custom modifiers is invalid for any reason
         if (__DEV__) {
           const modifiers = [
-            ...state.options.modifiers,
             ...state.orderedModifiers,
+            ...state.options.modifiers,
           ];
 
-          validateModifiers(
-            modifiers.filter(
-              (modifier, index) => modifiers.indexOf(modifier) === index
-            )
-          );
+          validateModifiers(uniqueBy(modifiers, ({ name }) => name));
         }
 
         if (state.isCreated) {

--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           ];
 
           if (enabled && typeof fn === 'function') {
-            fn({ state, options, name, instance });
+            state = fn({ state, options, name, instance }) || state;
           }
         }
       },
@@ -232,7 +232,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           const callbackFn = rest[callback];
 
           if (enabled && typeof callbackFn === 'function') {
-            callbackFn({ state, name, instance, options });
+            state = callbackFn({ state, name, instance, options }) || state;
           }
         }
       );

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,84 @@
+// @flow
+import { createPopper } from './';
+
+const reference = document.createElement('div');
+const getPopper = () => document.createElement('div');
+
+const testModifier = {
+  name: 'test',
+  phase: 'main',
+  enabled: true,
+};
+
+it('returns expected instance object', () => {
+  expect(createPopper(reference, getPopper())).toMatchSnapshot();
+});
+
+it('runs `onLoad` modifiers callback on create', () => {
+  const spy = jest.fn();
+
+  createPopper(reference, getPopper(), {
+    modifiers: [
+      {
+        ...testModifier,
+        onLoad: spy,
+      },
+    ],
+  });
+
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+it('does not run `onDestroy` modifiers callback on create', () => {
+  const spy = jest.fn();
+
+  createPopper(reference, getPopper(), {
+    modifiers: [
+      {
+        ...testModifier,
+        onDestroy: spy,
+      },
+    ],
+  });
+
+  expect(spy).not.toHaveBeenCalled();
+});
+
+describe('.setOptions() method', () => {
+  it('correctly updates `placement`', () => {
+    const popper = createPopper(reference, getPopper(), {
+      placement: 'right',
+    });
+
+    popper.setOptions({ placement: 'left' });
+
+    expect(popper.state.options.placement).toBe('left');
+  });
+
+  it('correctly updates `modifiers`', () => {
+    const popper = createPopper(reference, getPopper(), { modifiers: [] });
+    const modifier = { name: 'test', phase: 'main' };
+
+    popper.setOptions({ modifiers: [modifier] });
+
+    expect(popper.state.orderedModifiers.includes(modifier)).toBe(true);
+  });
+});
+
+describe('.destroy() method', () => {
+  it('runs `onDestroy` modifiers callback', () => {
+    const spy = jest.fn();
+
+    createPopper(reference, getPopper(), {
+      placement: 'right',
+      modifiers: [
+        {
+          ...testModifier,
+          onDestroy: spy,
+        },
+      ],
+    }).destroy();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -31,8 +31,6 @@ function applyStyles({ state }: ModifierArguments<{||}>) {
       }
     });
   });
-
-  return state;
 }
 
 function onDestroy({ state }: ModifierArguments<{||}>) {

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -22,7 +22,7 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   const len = isVertical ? 'height' : 'width';
 
   if (!arrowElement) {
-    return state;
+    return;
   }
 
   const paddingObject = state.modifiersData[`${name}#persistent`].padding;
@@ -54,8 +54,6 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   // Prevents breaking syntax highlighting...
   const axisProp: string = axis;
   state.modifiersData[name] = { [axisProp]: center };
-
-  return state;
 }
 
 function onLoad({ state, options, name }: ModifierArguments<Options>) {
@@ -66,7 +64,7 @@ function onLoad({ state, options, name }: ModifierArguments<Options>) {
     arrowElement = state.elements.popper.querySelector(arrowElement);
 
     if (!arrowElement) {
-      return state;
+      return;
     }
   }
 
@@ -79,8 +77,6 @@ function onLoad({ state, options, name }: ModifierArguments<Options>) {
         ].join(' ')
       );
     }
-
-    return state;
   }
 
   state.elements.arrow = arrowElement;
@@ -91,8 +87,6 @@ function onLoad({ state, options, name }: ModifierArguments<Options>) {
         : expandToHashMap(padding, basePlacements)
     ),
   };
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/computeStyles.js
+++ b/src/modifiers/computeStyles.js
@@ -90,8 +90,6 @@ function computeStyles({ state, options }: ModifierArguments<Options>) {
     ...state.attributes.popper,
     'data-popper-placement': state.placement,
   };
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -43,8 +43,6 @@ function onLoad({
   state.modifiersData[`${name}#persistent`] = { scroll, resize };
 
   toggleEventListeners({ state, instance, scroll, resize });
-
-  return state;
 }
 
 function onDestroy({ state, instance }: ModifierArguments<Options>) {
@@ -72,8 +70,6 @@ function update({
   state.modifiersData[`${name}#persistent`] = { scroll, resize };
 
   toggleEventListeners({ state, instance, scroll, resize });
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -84,7 +84,7 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
       state.reset = true;
     }
 
-    return state;
+    return;
   }
 
   const basePlacement = getBasePlacement(flippedPlacement);
@@ -124,14 +124,10 @@ function flip({ state, options, name }: ModifierArguments<Options>) {
   if (!fits) {
     state.modifiersData[name].index += 1;
     state.reset = true;
-    return state;
   } else if (fits && state.placement !== flippedPlacement) {
     state.placement = flippedPlacement;
     state.reset = true;
-    return state;
   }
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/hide.js
+++ b/src/modifiers/hide.js
@@ -57,8 +57,6 @@ function hide({ state, name }: ModifierArguments<Options>) {
     'data-popper-reference-hidden': isReferenceHidden,
     'data-popper-escaped': hasPopperEscaped,
   };
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/offset.js
+++ b/src/modifiers/offset.js
@@ -52,8 +52,6 @@ function offset({ state, options, name }: ModifierArguments<Options>) {
   state.modifiersData.popperOffsets.y += y;
 
   state.modifiersData[name] = data;
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/popperOffsets.js
+++ b/src/modifiers/popperOffsets.js
@@ -13,8 +13,6 @@ function popperOffsets({ state, name }: ModifierArguments<{||}>) {
     strategy: 'absolute',
     placement: state.placement,
   });
-
-  return state;
 }
 
 export default ({

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -171,8 +171,6 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
   }
 
   state.modifiersData[name] = data;
-
-  return state;
 }
 
 export default ({

--- a/src/types.js
+++ b/src/types.js
@@ -74,9 +74,9 @@ export type Modifier<Options> = {|
   phase: ModifierPhases,
   requires?: Array<string>,
   optionallyRequires?: Array<string>,
-  fn: (ModifierArguments<Options>) => void,
-  onLoad?: (ModifierArguments<Options>) => void,
-  onDestroy?: (ModifierArguments<Options>) => void,
+  fn: (ModifierArguments<Options>) => ?State,
+  onLoad?: (ModifierArguments<Options>) => ?State,
+  onDestroy?: (ModifierArguments<Options>) => ?State,
   options?: Obj,
   data?: Obj,
 |};

--- a/src/types.js
+++ b/src/types.js
@@ -29,6 +29,7 @@ export type StateOffsets = {|
 |};
 
 export type State = {|
+  isCreated: boolean,
   elements: {|
     reference: Element | VirtualElement,
     popper: HTMLElement,
@@ -54,6 +55,7 @@ export type State = {|
 |};
 
 export type Instance = {|
+  state: State,
   destroy: () => void,
   forceUpdate: () => void,
   update: () => Promise<void>,
@@ -72,8 +74,8 @@ export type Modifier<Options> = {|
   phase: ModifierPhases,
   requires?: Array<string>,
   optionallyRequires?: Array<string>,
-  fn: (ModifierArguments<Options>) => State,
-  onLoad?: (ModifierArguments<Options>) => ?State,
+  fn: (ModifierArguments<Options>) => void,
+  onLoad?: (ModifierArguments<Options>) => void,
   onDestroy?: (ModifierArguments<Options>) => void,
   options?: Obj,
   data?: Obj,

--- a/src/utils/uniqueBy.js
+++ b/src/utils/uniqueBy.js
@@ -1,0 +1,14 @@
+// @flow
+
+export default function uniqueBy<T>(arr: Array<T>, fn: T => any): Array<T> {
+  const identifiers = new Set();
+
+  return arr.filter(item => {
+    const identifier = fn(item);
+
+    if (!identifiers.has(identifier)) {
+      identifiers.add(identifier);
+      return true;
+    }
+  });
+}

--- a/src/utils/uniqueBy.test.js
+++ b/src/utils/uniqueBy.test.js
@@ -1,0 +1,13 @@
+// @flow
+import uniqueBy from './uniqueBy';
+
+it('filters out duplicate items based by an identifier', () => {
+  const a = { name: 'a' };
+  const b = { name: 'b' };
+  const c = { name: 'c' };
+  const d = { name: 'd' };
+
+  const items = [a, b, c, a, a, d, c, c, d, b];
+
+  expect(uniqueBy(items, ({ name }) => name)).toEqual([a, b, c, d]);
+});


### PR DESCRIPTION
- Runs `onLoad` and `onDestroy` in `.setOptions()`
- I don't see the need to `return state` since the user just modifies a permanent state object. There's no returning of a clone involved, so it's not necessary? It's easy to forget to remember to return the state object too so this seems less bug prone.
- `validateModifiers` was not running for modifiers if they got filtered out of `state.orderedModifiers` (e.g. they have no `phase` property - I kept forgetting it)
- Adds the `state` object to the instance