### PR TITLE
refactor(VirtualElement): remove contextElement and add docs

### DIFF
--- a/docs/src/components/Demos.js
+++ b/docs/src/components/Demos.js
@@ -164,3 +164,58 @@ export const FlipDemo = () => {
     </>
   );
 };
+
+export const VirtualElementDemo = () => {
+  const { reference, popper, instance } = usePopper({
+    placement: 'right-start',
+    modifiers: [
+      {
+        name: 'flip',
+        enabled: false,
+      },
+      {
+        name: 'preventOverflow',
+        options: {
+          tether: false,
+          altAxis: true,
+        },
+      },
+    ],
+  });
+
+  if (!reference.current) {
+    reference.current = {
+      getBoundingClientRect: generateGetBoundingClientRect(),
+    };
+  }
+
+  function generateGetBoundingClientRect(x = 0, y = 0) {
+    return () => ({
+      width: 0,
+      height: 0,
+      top: y,
+      right: x,
+      bottom: y,
+      left: x,
+    });
+  }
+
+  function handleMouseMove({ clientX: x, clientY: y }) {
+    const getBoundingClientRect = generateGetBoundingClientRect(x, y);
+    reference.current.getBoundingClientRect = getBoundingClientRect;
+    instance.current.update();
+  }
+
+  useLayoutEffect(() => {
+    document.addEventListener('mousemove', handleMouseMove);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+    };
+  });
+
+  return (
+    <ClippingParent scrollable>
+      <Tooltip ref={popper}>Tooltip</Tooltip>
+    </ClippingParent>
+  );
+};

--- a/docs/src/components/Popper.js
+++ b/docs/src/components/Popper.js
@@ -6,7 +6,7 @@ import { css } from '@emotion/core';
 export const usePopper = (options = {}) => {
   const referenceRef = useRef();
   const popperRef = useRef();
-  const popperInstanceRef = useRef();
+  const instanceRef = useRef();
 
   const mergedOptions = useMemo(
     () => ({
@@ -31,28 +31,29 @@ export const usePopper = (options = {}) => {
   );
 
   useLayoutEffect(() => {
-    const popperInstance = createPopper(
+    const instance = createPopper(
       referenceRef.current,
       popperRef.current,
       mergedOptions
     );
 
-    popperInstanceRef.current = popperInstance;
+    instanceRef.current = instance;
 
     return () => {
-      popperInstance.destroy();
+      instance.destroy();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useLayoutEffect(() => {
-    popperInstanceRef.current.setOptions(mergedOptions);
-    popperInstanceRef.current.update();
+    instanceRef.current.setOptions(mergedOptions);
+    instanceRef.current.update();
   }, [mergedOptions]);
 
   return {
     reference: referenceRef,
     popper: popperRef,
+    instance: instanceRef,
   };
 };
 

--- a/docs/src/pages/docs/virtual-elements.mdx
+++ b/docs/src/pages/docs/virtual-elements.mdx
@@ -1,0 +1,55 @@
+---
+title: Virtual Elements
+---
+
+import { VirtualElementDemo } from '../../components/Demos';
+
+# Virtual Elements
+
+You can use a virtual element instead of a real DOM element as the reference.
+This allows you to position the popper relative to a virtual area defined by any
+coordinates you desire.
+
+A common use case for this is making the popper follow the mouse cursor, where
+the cursor acts as a point reference.
+
+A virtual element is a plain object with only one property – a custom
+`getBoundingClientRect` function that returns a custom `ClientRect` object:
+
+```flow
+type VirtualElement = {|
+  getBoundingClientRect: () => ClientRect | DOMRect,
+|};
+```
+
+## Demo
+
+<VirtualElementDemo />
+
+## Usage
+
+This will make the popper follow the mouse cursor as seen in the demo above:
+
+```js
+function generateGetBoundingClientRect(x = 0, y = 0) {
+  return () => ({
+    width: 0,
+    height: 0,
+    top: y,
+    right: x,
+    bottom: y,
+    left: x,
+  });
+}
+
+const virtualElement = {
+  getBoundingClientRect: generateGetBoundingClientRect(),
+};
+
+const instance = createPopper(virtualElement, popper);
+
+document.addEventListener('mousemove', ({ clientX: x, clientY: y }) => {
+  virtualElement.getBoundingClientRect = generateGetBoundingClientRect(x, y);
+  instance.update();
+});
+```

--- a/docs/src/utils/processRoutes.js
+++ b/docs/src/utils/processRoutes.js
@@ -1,5 +1,12 @@
 const BLACKLIST = new Set(['/404/']);
-const DIR_ORDER = ['tippy', 'modifiers', 'utils', 'typings', 'browser-support'];
+const DIR_ORDER = [
+  'tippy',
+  'modifiers',
+  'utils',
+  'virtual-elements',
+  'typings',
+  'browser-support',
+];
 const MODIFIER_ORDER = [
   'Popper Offsets',
   'Offset',

--- a/src/dom-utils/unwrapVirtualElement.js
+++ b/src/dom-utils/unwrapVirtualElement.js
@@ -1,9 +1,0 @@
-// @flow
-import type { VirtualElement } from '../types';
-import { isElement } from './instanceOf';
-
-export default function unwrapVirtualElement(
-  element: Element | VirtualElement
-): Element {
-  return isElement(element) ? element : element.contextElement;
-}

--- a/src/types.js
+++ b/src/types.js
@@ -112,6 +112,5 @@ export type SideObject = {|
 export type Padding = number | $Shape<SideObject>;
 
 export type VirtualElement = {|
-  contextElement: HTMLElement,
   getBoundingClientRect: () => ClientRect | DOMRect,
 |};

--- a/src/utils/detectOverflow.js
+++ b/src/utils/detectOverflow.js
@@ -3,9 +3,9 @@ import type { State, SideObject } from '../types';
 import type { Placement, Boundary, RootBoundary, Context } from '../enums';
 import getBoundingClientRect from '../dom-utils/getBoundingClientRect';
 import getClippingRect from '../dom-utils/getClippingRect';
-import unwrapVirtualElement from '../dom-utils/unwrapVirtualElement';
-import computeOffsets from '../utils/computeOffsets';
-import rectToClientRect from '../utils/rectToClientRect';
+import getDocumentElement from '../dom-utils/getDocumentElement';
+import computeOffsets from './computeOffsets';
+import rectToClientRect from './rectToClientRect';
 import {
   clippingParents,
   reference,
@@ -14,6 +14,7 @@ import {
   top,
   right,
 } from '../enums';
+import { isElement } from '../dom-utils/instanceOf';
 
 type Options = {
   placement: Placement,
@@ -42,7 +43,7 @@ export default function detectOverflow(
   const element = state.elements[altBoundary ? altContext : elementContext];
 
   const clippingClientRect = getClippingRect(
-    unwrapVirtualElement(element),
+    isElement(element) ? element : getDocumentElement(state.elements.popper),
     boundary,
     rootBoundary
   );

--- a/tests/visual/virtual.html
+++ b/tests/visual/virtual.html
@@ -38,31 +38,25 @@
   const reference = document.querySelector('#reference');
   const popper = document.querySelector('#popper');
 
-  const ref = {
-    contextElement: reference,
-    getBoundingClientRect: () => ({
-      width: 200,
-      height: 150,
-      top: 100,
-      right: 300,
-      bottom: 250,
-      left: 100,
-    }),
-  };
-
-  window.instance = createPopper(ref, popper, {
-    placement: 'bottom',
-  });
-
-  document.addEventListener('mousemove', ({ clientX, clientY }) => {
-    ref.getBoundingClientRect = () => ({
-      top: clientY,
-      right: clientX,
-      bottom: clientY,
-      left: clientX,
+  function generateGetBoundingClientRect(x = 0, y = 0) {
+    return () => ({
       width: 0,
       height: 0,
+      top: y,
+      right: x,
+      bottom: y,
+      left: x,
     });
+  }
+
+  const virtualElement = {
+    getBoundingClientRect: generateGetBoundingClientRect(),
+  };
+
+  const instance = createPopper(virtualElement, popper);
+
+  document.addEventListener('mousemove', ({ clientX: x, clientY: y }) => {
+    virtualElement.getBoundingClientRect = generateGetBoundingClientRect(x, y);
     instance.update();
   });
 </script>


### PR DESCRIPTION
There's no need for `contextElement` anymore since the offsetParent is always relative to the popper element.