### PR TITLE
fix: createPopper argument types

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,5 @@
 // @flow
 import type { Placement, ModifierPhases } from './enums';
-export type JQueryWrapper = Array<HTMLElement> & { jquery: string };
 
 export type Obj = { [key: string]: any };
 

--- a/src/utils/unwrapJqueryElement.js
+++ b/src/utils/unwrapJqueryElement.js
@@ -1,9 +1,0 @@
-// @flow
-import type { JQueryWrapper } from '../types';
-
-export default function unwrapJqueryElement(
-  element: HTMLElement | JQueryWrapper
-): HTMLElement {
-  // $FlowFixMe: need to get type refinement work
-  return element.hasOwnProperty('jquery') ? element[0] : element;
-}


### PR DESCRIPTION
Should fix #917 @HHogg 

I removed the whole `jQueryWrapper` handling because I don't think it's useful moving forward with such a modern library, Tippy doesn't handle this at all and doesn't get complaints.