### PR TITLE
feat: effects

### DIFF
--- a/docs/src/pages/docs/modifiers/index.mdx
+++ b/docs/src/pages/docs/modifiers/index.mdx
@@ -39,8 +39,7 @@ type Modifier = {|
   // Optional properties
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
-  onLoad?: (ModifierArguments<Options>) => ?State,
-  onDestroy?: (ModifierArguments<Options>) => ?State,
+  effect?: (ModifierArguments<Options>) => ?() => void,
   options?: any,
   data?: {},
 |};
@@ -138,16 +137,31 @@ exists, because `offset` mutates the `popperOffsets` data, which
 In short, the modifier depends upon this list of modifiers' **behavior** (or
 mutations to dependent data from other modifiers) to work.
 
-### `onLoad`
+### `effect`
 
-This function is executed when the Popper instance is created or when its
-options are updated. It can be useful if you want to store some persistent data,
-which the `arrow` and `eventListeners` modifiers use.
+This function allows you to execute arbitrary code (effects) before the first
+update cycle is ran. Perform effects in the function and return a cleanup
+function if necessary:
 
-### `onDestroy`
+```js
+function effect() {
+  // perform side effects
+  return () => {
+    // cleanup side effects
+  };
+}
+```
 
-Just like `onLoad`, but runs when the Popper instance is destroyed or when its
-options are updated. Use this to clean up the code run in `onLoad`.
+Examples where this is useful involve code that is not necessary to be run on
+every update, rather only when the instance lifecycle changes (created, updated,
+or destroyed):
+
+- The `eventListeners` modifier uses this to add and remove `window`/`document`
+  event listeners which is not part of the main modifier update cycle.
+- The `arrow` modifier uses this to add the element to `state.elements`. The
+  `arrow` modifier is dependent on `preventOverflow` (run after), but
+  `preventOverflow` depends on `state.elements.arrow`. Since effects are run
+  before the first update cycle, the problem is resolved.
 
 ### `options`
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -11,7 +11,6 @@ Object {
       "popper": <div />,
       "reference": <div />,
     },
-    "isCreated": true,
     "modifiersData": Object {},
     "options": Object {
       "modifiers": Array [],

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,6 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     const popperElement = unwrapJqueryElement(popper);
 
     let state: $Shape<State> = {
-      isCreated: false,
       placement: 'bottom',
       orderedModifiers: [],
       options: { ...DEFAULT_OPTIONS, ...defaultOptions },
@@ -71,9 +70,13 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
       styles: {},
     };
 
+    let effectCleanupFns: Array<() => void> = [];
+
     const instance = {
       state,
       setOptions(options) {
+        cleanupModifierEffects();
+
         state.options = {
           ...defaultOptions,
           ...options,
@@ -110,13 +113,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
           validateModifiers(uniqueBy(modifiers, ({ name }) => name));
         }
 
-        if (state.isCreated) {
-          runModifiersCallback('onDestroy');
-        }
-
-        runModifiersCallback('onLoad');
-
-        state.isCreated = true;
+        runModifierEffects();
       },
 
       // Sync update – it will always be executed, even if not necessary. This
@@ -206,7 +203,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
       ),
 
       destroy() {
-        runModifiersCallback('onDestroy');
+        cleanupModifierEffects();
       },
     };
 
@@ -224,16 +221,21 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
     // cycle. This is useful when a modifier adds some persistent data that
     // other modifiers need to use, but the modifier is run after the dependent
     // one.
-    function runModifiersCallback(callback: 'onLoad' | 'onDestroy') {
+    function runModifierEffects() {
       state.orderedModifiers.forEach(
-        ({ enabled, name, options = {}, ...rest }) => {
-          const callbackFn = rest[callback];
-
-          if (enabled && typeof callbackFn === 'function') {
-            state = callbackFn({ state, name, instance, options }) || state;
+        ({ enabled, name, options = {}, effect }) => {
+          if (enabled && typeof effect === 'function') {
+            const cleanupFn = effect({ state, name, instance, options });
+            const noopFn = () => {};
+            effectCleanupFns.push(cleanupFn || noopFn);
           }
         }
       );
+    }
+
+    function cleanupModifierEffects() {
+      effectCleanupFns.forEach(fn => fn());
+      effectCleanupFns = [];
     }
 
     instance.update();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -14,14 +14,14 @@ it('returns expected instance object', () => {
   expect(createPopper(reference, getPopper())).toMatchSnapshot();
 });
 
-it('runs `onLoad` modifiers callback on create', () => {
+it('runs modifier effects on create', () => {
   const spy = jest.fn();
 
   createPopper(reference, getPopper(), {
     modifiers: [
       {
         ...testModifier,
-        onLoad: spy,
+        effect: spy,
       },
     ],
   });
@@ -29,14 +29,14 @@ it('runs `onLoad` modifiers callback on create', () => {
   expect(spy).toHaveBeenCalledTimes(1);
 });
 
-it('does not run `onDestroy` modifiers callback on create', () => {
+it('does not run modifier effect cleanup functions on create', () => {
   const spy = jest.fn();
 
   createPopper(reference, getPopper(), {
     modifiers: [
       {
         ...testModifier,
-        onDestroy: spy,
+        effect: () => spy,
       },
     ],
   });
@@ -66,7 +66,7 @@ describe('.setOptions() method', () => {
 });
 
 describe('.destroy() method', () => {
-  it('runs `onDestroy` modifiers callback', () => {
+  it('runs effect cleanup functions', () => {
     const spy = jest.fn();
 
     createPopper(reference, getPopper(), {
@@ -74,7 +74,7 @@ describe('.destroy() method', () => {
       modifiers: [
         {
           ...testModifier,
-          onDestroy: spy,
+          effect: () => spy,
         },
       ],
     }).destroy();

--- a/src/modifiers/applyStyles.js
+++ b/src/modifiers/applyStyles.js
@@ -33,37 +33,39 @@ function applyStyles({ state }: ModifierArguments<{||}>) {
   });
 }
 
-function onDestroy({ state }: ModifierArguments<{||}>) {
-  Object.keys(state.elements).forEach(name => {
-    const element = state.elements[name];
-    const styleProperties = Object.keys(
-      state.styles.hasOwnProperty(name) ? { ...state.styles[name] } : {}
-    );
-    const attributes = state.attributes[name] || {};
+function effect({ state }: ModifierArguments<{||}>) {
+  return () => {
+    Object.keys(state.elements).forEach(name => {
+      const element = state.elements[name];
+      const styleProperties = Object.keys(
+        state.styles.hasOwnProperty(name) ? { ...state.styles[name] } : {}
+      );
+      const attributes = state.attributes[name] || {};
 
-    // Set all values to an empty string to unset them
-    const style = styleProperties.reduce(
-      (style, property) => ({
-        ...style,
-        [String(property)]: '',
-      }),
-      {}
-    );
+      // Set all values to an empty string to unset them
+      const style = styleProperties.reduce(
+        (style, property) => ({
+          ...style,
+          [String(property)]: '',
+        }),
+        {}
+      );
 
-    // arrow is optional + virtual elements
-    if (!isHTMLElement(element) || !getNodeName(element)) {
-      return;
-    }
+      // arrow is optional + virtual elements
+      if (!isHTMLElement(element) || !getNodeName(element)) {
+        return;
+      }
 
-    // Flow doesn't support to extend this property, but it's the most
-    // effective way to apply styles to an HTMLElement
-    // $FlowFixMe
-    Object.assign(element.style, style);
+      // Flow doesn't support to extend this property, but it's the most
+      // effective way to apply styles to an HTMLElement
+      // $FlowFixMe
+      Object.assign(element.style, style);
 
-    Object.keys(attributes).forEach(attribute =>
-      element.removeAttribute(attribute)
-    );
-  });
+      Object.keys(attributes).forEach(attribute =>
+        element.removeAttribute(attribute)
+      );
+    });
+  };
 }
 
 export default ({
@@ -71,6 +73,6 @@ export default ({
   enabled: true,
   phase: 'write',
   fn: applyStyles,
-  onDestroy,
+  effect,
   requires: ['computeStyles'],
 }: Modifier<{||}>);

--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -52,7 +52,7 @@ function arrow({ state, name }: ModifierArguments<Options>) {
   state.modifiersData[name] = { [axisProp]: center };
 }
 
-function onLoad({ state, options, name }: ModifierArguments<Options>) {
+function effect({ state, options, name }: ModifierArguments<Options>) {
   let { element: arrowElement = '[data-popper-arrow]', padding = 0 } = options;
 
   // CSS selector
@@ -73,6 +73,8 @@ function onLoad({ state, options, name }: ModifierArguments<Options>) {
         ].join(' ')
       );
     }
+
+    return;
   }
 
   state.elements.arrow = arrowElement;
@@ -90,7 +92,7 @@ export default ({
   enabled: true,
   phase: 'main',
   fn: arrow,
-  onLoad,
+  effect,
   requires: ['popperOffsets'],
   requiresIfExists: ['preventOverflow'],
 }: Modifier<Options>);

--- a/src/modifiers/eventListeners.js
+++ b/src/modifiers/eventListeners.js
@@ -9,81 +9,43 @@ type Options = {
 
 const passive = { passive: true };
 
-function toggleEventListeners({ state, instance, scroll, resize }) {
-  if (scroll != null) {
-    const scrollParents = [
-      ...state.scrollParents.reference,
-      ...state.scrollParents.popper,
-    ];
+function effect({ state, instance, options }: ModifierArguments<Options>) {
+  const { scroll = true, resize = true } = options;
 
+  const window = getWindow(state.elements.popper);
+  const scrollParents = [
+    ...state.scrollParents.reference,
+    ...state.scrollParents.popper,
+  ];
+
+  if (scroll) {
     scrollParents.forEach(scrollParent => {
-      if (scroll) {
-        scrollParent.addEventListener('scroll', instance.update, passive);
-      } else {
-        scrollParent.removeEventListener('scroll', instance.update, passive);
-      }
+      scrollParent.addEventListener('scroll', instance.update, passive);
     });
   }
 
-  if (resize != null) {
-    const window = getWindow(state.elements.popper);
+  if (resize) {
+    window.addEventListener('resize', instance.update, passive);
+  }
+
+  return () => {
+    if (scroll) {
+      scrollParents.forEach(scrollParent => {
+        scrollParent.removeEventListener('scroll', instance.update, passive);
+      });
+    }
 
     if (resize) {
-      window.addEventListener('resize', instance.update, passive);
-    } else {
       window.removeEventListener('resize', instance.update, passive);
     }
-  }
-}
-
-function onLoad({
-  state,
-  instance,
-  name,
-  options,
-}: ModifierArguments<Options>) {
-  const { scroll = true, resize = true } = options;
-
-  // cache initial options so we can compare them later
-  state.modifiersData[`${name}#persistent`] = { scroll, resize };
-
-  toggleEventListeners({ state, instance, scroll, resize });
-}
-
-function onDestroy({ state, instance }: ModifierArguments<Options>) {
-  toggleEventListeners({ state, instance, scroll: false, resize: false });
-}
-
-function update({
-  state,
-  options,
-  instance,
-  name,
-}: ModifierArguments<Options>) {
-  const data = state.modifiersData[`${name}#persistent`];
-  let { scroll = true, resize = true } = options;
-
-  // Set options to `null` if they didn't change, so we know not to run any
-  // logic
-  if (data.scroll === scroll) {
-    scroll = null;
-  }
-  if (data.resize === resize) {
-    resize = null;
-  }
-
-  // Update cache
-  state.modifiersData[`${name}#persistent`] = { scroll, resize };
-
-  toggleEventListeners({ state, instance, scroll, resize });
+  };
 }
 
 export default ({
   name: 'eventListeners',
   enabled: true,
   phase: 'write',
-  fn: update,
-  onLoad,
-  onDestroy,
+  fn: () => {},
+  effect,
   data: {},
 }: Modifier<Options>);

--- a/src/types.js
+++ b/src/types.js
@@ -75,8 +75,7 @@ export type Modifier<Options> = {|
   requires?: Array<string>,
   requiresIfExists?: Array<string>,
   fn: (ModifierArguments<Options>) => ?State,
-  onLoad?: (ModifierArguments<Options>) => ?State,
-  onDestroy?: (ModifierArguments<Options>) => ?State,
+  effect?: (ModifierArguments<Options>) => ?() => void,
   options?: Obj,
   data?: Obj,
 |};

--- a/src/utils/validateModifiers.js
+++ b/src/utils/validateModifiers.js
@@ -11,7 +11,7 @@ const VALID_PROPERTIES = [
   'enabled',
   'phase',
   'fn',
-  'onLoad',
+  'effect',
   'requires',
   'options',
 ];
@@ -71,26 +71,13 @@ export default function validateModifiers(modifiers: Array<any>): void {
             );
           }
           break;
-        case 'onLoad':
-          if (typeof modifier.onLoad !== 'function') {
+        case 'effect':
+          if (typeof modifier.effect !== 'function') {
             console.error(
               format(
                 INVALID_MODIFIER_ERROR,
                 modifier.name,
-                '"onLoad"',
-                '"function"',
-                `"${String(modifier.fn)}"`
-              )
-            );
-          }
-          break;
-        case 'onDestroy':
-          if (typeof modifier.onDestroy !== 'function') {
-            console.error(
-              format(
-                INVALID_MODIFIER_ERROR,
-                modifier.name,
-                '"onDestroy"',
+                '"effect"',
                 '"function"',
                 `"${String(modifier.fn)}"`
               )


### PR DESCRIPTION
This replaces `onLoad` / `onDestroy` and works like React's `useEffect` where the cleanup function is returned as a function:

```js
function effect() {
  // perform side effects
  return () => {
    // cleanup side effects
  };
}
```

This naming works better with `.setOptions()` since `onLoad` / `onDestroy` was getting called for option changes, which doesn't really make semantic sense. Grouping these under a unified "effect" works better, where variables can be shared in the closure instead of two separate callback functions.

The previous `onDestroy` was also being called at the wrong location (should be called at the top). `State` can no longer be returned from these but I don't see how that was useful.