### PR TITLE
fix(preventOverflow): make viewport default rootBoundary

### DIFF
--- a/docs/src/pages/docs/modifiers/prevent-overflow.mdx
+++ b/docs/src/pages/docs/modifiers/prevent-overflow.mdx
@@ -31,7 +31,7 @@ type Options = {
   altAxis: boolean, // false
   padding: Padding, // 0
   boundary: Boundary, // "clippingParents"
-  rootBoundary: RootBoundary, // "document"
+  rootBoundary: RootBoundary, // "viewport"
   tether: boolean, // true
   tetherOffset: TetherOffset, // 0
 };
@@ -152,9 +152,9 @@ createPopper(reference, popper, {
 ### `rootBoundary`
 
 This describes the root boundary that will be checked for overflow. There are
-only two "roots" – the viewport and the document. `"document"` is default, which
-is the entire page which can potentially be scrolled. `"viewport"` is the area
-of the document the user can actually see on the screen.
+only two "roots" – the viewport and the document. `"viewport"` is default, which
+is the area of the document the user can actually see on the screen.
+`"document"` is the entire page which can be potentially scrolled.
 
 ```js
 createPopper(reference, popper, {

--- a/src/modifiers/preventOverflow.js
+++ b/src/modifiers/preventOverflow.js
@@ -7,6 +7,7 @@ import {
   bottom,
   clippingParents,
   start,
+  viewport,
 } from '../enums';
 import type { Placement, Boundary, RootBoundary } from '../enums';
 import type { Rect, ModifierArguments, Modifier, Padding } from '../types';
@@ -54,7 +55,7 @@ function preventOverflow({ state, options, name }: ModifierArguments<Options>) {
     mainAxis: checkMainAxis = true,
     altAxis: checkAltAxis = false,
     boundary = clippingParents,
-    rootBoundary = 'document',
+    rootBoundary = viewport,
     tether = true,
     tetherOffset = 0,
     padding = 0,

--- a/tests/visual/modifiers/flip/checkVariation-larger.html
+++ b/tests/visual/modifiers/flip/checkVariation-larger.html
@@ -39,9 +39,9 @@
     placement: 'right-start',
     modifiers: [
       {
-        name: 'flip',
+        name: 'preventOverflow',
         options: {
-          flipVariations: true,
+          rootBoundary: 'document',
         },
       },
     ],

--- a/tests/visual/modifiers/flip/checkVariation-shorter.html
+++ b/tests/visual/modifiers/flip/checkVariation-shorter.html
@@ -39,9 +39,9 @@
     placement: 'right-start',
     modifiers: [
       {
-        name: 'flip',
+        name: 'preventOverflow',
         options: {
-          flipVariations: true,
+          rootBoundary: 'document',
         },
       },
     ],

--- a/tests/visual/modifiers/flip/checkVariation.html
+++ b/tests/visual/modifiers/flip/checkVariation.html
@@ -41,7 +41,6 @@
       {
         name: 'flip',
         options: {
-          flipVariations: true,
           fallbackPlacements: [
             'top-start',
             'right-start',


### PR DESCRIPTION
This matches `flip`. 

Reasoning:

> If our goal is to keep the popper in view as best as possible, this makes sense I think. The reason is, the viewport is as valid as a clipping element as a scrolling container for example

Issue: https://github.com/popperjs/react-popper/issues/295

When using `flipVariations` this can make the popper not be aligned to the edge, which may be more desirable than preventing the overflow. In that case the user can choose `document` as the `rootBoundary`

This will also fix transition issues of the popper by default when its content changes near a boundary, e.g. Tippy's singleton which stretches the document.