### PR TITLE
feat: export default modifiers

### DIFF
--- a/src/popper-lite.js
+++ b/src/popper-lite.js
@@ -5,9 +5,14 @@ import popperOffsets from './modifiers/popperOffsets';
 import computeStyles from './modifiers/computeStyles';
 import applyStyles from './modifiers/applyStyles';
 
-const createPopper = popperGenerator({
-  defaultModifiers: [eventListeners, popperOffsets, computeStyles, applyStyles],
-});
+const defaultModifiers = [
+  eventListeners,
+  popperOffsets,
+  computeStyles,
+  applyStyles,
+];
+
+const createPopper = popperGenerator({ defaultModifiers });
 
 // eslint-disable-next-line import/no-unused-modules
-export { createPopper, popperGenerator };
+export { createPopper, popperGenerator, defaultModifiers };

--- a/src/popper.js
+++ b/src/popper.js
@@ -25,4 +25,4 @@ const defaultModifiers = [
 const createPopper = popperGenerator({ defaultModifiers });
 
 // eslint-disable-next-line import/no-unused-modules
-export { createPopper, popperGenerator };
+export { createPopper, popperGenerator, defaultModifiers };


### PR DESCRIPTION
When using `popperGenerator`, this allows you to inherit or spread in the modifiers while also adding some more.

```js
import { popperGenerator, defaultModifiers } from '@popperjs/core/lib/popper-lite';
import flip from '@popperjs/core/lib/modifiers/flip';

const createPopper = popperGenerator({
  defaultModifiers: [...defaultModifiers, flip],
});
```