### PR TITLE
fix: allow arrow elements to be in shadow DOM

### DIFF
--- a/src/modifiers/arrow.js
+++ b/src/modifiers/arrow.js
@@ -64,7 +64,10 @@ function effect({ state, options, name }: ModifierArguments<Options>) {
     }
   }
 
-  if (!state.elements.popper.contains(arrowElement)) {
+  if (
+    !state.elements.popper.contains(arrowElement) &&
+    (!state.elements.popper.shadowRoot || !state.elements.popper.shadowRoot.contains(arrowElement))
+  ) {
     if (__DEV__) {
       console.error(
         [


### PR DESCRIPTION
This is a possible fix for issue #940 