### PR TITLE
Fixed typo in docs

### DIFF
--- a/docs/src/pages/docs/modifiers/flip.mdx
+++ b/docs/src/pages/docs/modifiers/flip.mdx
@@ -96,7 +96,7 @@ createPopper(reference, popper, {
     {
       name: 'flip',
       options: {
-        area: element,
+        boundary: element,
       },
     },
   ],

--- a/docs/src/pages/docs/modifiers/prevent-overflow.mdx
+++ b/docs/src/pages/docs/modifiers/prevent-overflow.mdx
@@ -120,7 +120,7 @@ createPopper(reference, popper, {
     {
       name: 'preventOverflow',
       options: {
-        area: element,
+        boundary: element,
       },
     },
   ],


### PR DESCRIPTION
I think, `area` was in the early implementation, but now, modificators don't have area option in the code
<!--
Thanks for your help!

Tests will automatically run and will report back any issues with your PR, just sit and relax!

While you wait, why don't you add some documentation or tests to cover your changes?
-->
