### PR TITLE
refactor: remove String.prototype.includes usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,9 @@ import orderModifiers from './utils/orderModifiers';
 import debounce from './utils/debounce';
 import validateModifiers from './utils/validateModifiers';
 import uniqueBy from './utils/uniqueBy';
+import getBasePlacement from './utils/getBasePlacement';
 import { isElement } from './dom-utils/instanceOf';
+import { auto } from './enums';
 
 export * from './types';
 export * from './enums';
@@ -108,7 +110,7 @@ export function popperGenerator(generatorOptions: PopperGeneratorArgs = {}) {
 
           validateModifiers(modifiers);
 
-          if (state.options.placement.includes('auto')) {
+          if (getBasePlacement(state.options.placement) === auto) {
             const flipModifier = orderedModifiers.find(
               ({ name }) => name === 'flip'
             );

--- a/src/modifiers/flip.js
+++ b/src/modifiers/flip.js
@@ -7,7 +7,8 @@ import getOppositeVariationPlacement from '../utils/getOppositeVariationPlacemen
 import detectOverflow from '../utils/detectOverflow';
 import computeAutoPlacement from '../utils/computeAutoPlacement';
 import uniqueBy from '../utils/uniqueBy';
-import { bottom, top, start, right, left } from '../enums';
+import { bottom, top, start, right, left, auto } from '../enums';
+import getVariation from '../utils/getVariation';
 
 type Options = {
   fallbackPlacements: Array<Placement>,
@@ -18,7 +19,7 @@ type Options = {
 };
 
 function getExpandedFallbackPlacements(placement: Placement): Array<Placement> {
-  if (placement.includes('auto')) {
+  if (getBasePlacement(placement) === auto) {
     return [];
   }
 
@@ -52,7 +53,7 @@ function flip({ state, options }: ModifierArguments<Options>) {
 
   const placements = uniqueBy(
     [preferredPlacement, ...fallbackPlacements].reduce((acc, placement) => {
-      return placement.includes('auto')
+      return getBasePlacement(placement) === auto
         ? acc.concat(
             computeAutoPlacement(state, {
               placement,
@@ -72,7 +73,7 @@ function flip({ state, options }: ModifierArguments<Options>) {
 
   const placementOverflowData = placements.reduce((acc, placement) => {
     const basePlacement = getBasePlacement(placement);
-    const isStartVariation = placement.includes(start);
+    const isStartVariation = getVariation(placement) === start;
     const isVertical = [top, bottom].includes(basePlacement);
     const len = isVertical ? 'width' : 'height';
 


### PR DESCRIPTION
This isn't included in the IE11 polyfill list and this util makes more sense to use